### PR TITLE
Update notebook for TensorFlow 2.3

### DIFF
--- a/Quantile Loss.ipynb
+++ b/Quantile Loss.ipynb
@@ -2,33 +2,41 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/jacob/anaconda3/envs/kiromic/lib/python3.6/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.\n",
-      "  from ._conv import register_converters as _register_converters\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
+    "from tensorflow.keras.layers.experimental import preprocessing\n",
+    "from tensorflow.keras import layers\n",
+    "import matplotlib.pyplot as plt\n",
     "import tensorflow as tf\n",
     "import pandas as pd\n",
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "%matplotlib inline\n",
-    "\n",
-    "# Initialize session\n",
-    "sess = tf.Session()"
+    "import numpy as np"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'2.3.1'"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tf.__version__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,209 +51,173 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Multi-Quantile loss function:**"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create network\n",
-    "class q_model:\n",
-    "    def __init__(self, \n",
-    "                 sess, \n",
-    "                 quantiles, \n",
-    "                 in_shape=1, \n",
-    "                 out_shape=1, \n",
-    "                 batch_size=32):\n",
-    "        \n",
-    "        self.sess = sess\n",
+    "class MultiQuantileLoss(tf.keras.losses.Loss):\n",
+    "    \n",
+    "    def __init__(self, quantiles:list, **kwargs):\n",
+    "        super(MultiQuantileLoss, self).__init__(**kwargs)\n",
     "        \n",
     "        self.quantiles = quantiles\n",
-    "        self.num_quantiles = len(quantiles)\n",
+    "\n",
+    "    def call(self, y_true, y_pred):\n",
     "        \n",
-    "        self.in_shape = in_shape\n",
-    "        self.out_shape = out_shape\n",
-    "        self.batch_size = batch_size\n",
+    "        # get quantile value\n",
+    "        q_id = int(y_pred.name.split(\"/\")[1][1:])\n",
+    "        q = self.quantiles[q_id]\n",
     "        \n",
-    "        self.outputs = []\n",
-    "        self.losses = []\n",
-    "        self.loss_history = []\n",
-    "        \n",
-    "        self.build_model()\n",
-    "        \n",
-    "    def build_model(self, scope='q_model', reuse=tf.AUTO_REUSE): \n",
-    "        with tf.variable_scope(scope, reuse=reuse) as scope:\n",
-    "            self.x = tf.placeholder(tf.float32, shape=(None, self.in_shape))\n",
-    "            self.y = tf.placeholder(tf.float32, shape=(None, self.out_shape))\n",
-    "\n",
-    "            self.layer0 = tf.layers.dense(self.x, \n",
-    "                                    units=32, \n",
-    "                                    activation=tf.nn.relu)\n",
-    "            self.layer1 = tf.layers.dense(self.layer0, \n",
-    "                                    units=32, \n",
-    "                                    activation=tf.nn.relu)\n",
-    "\n",
-    "            # Create outputs and losses for all quantiles\n",
-    "            for i in range(self.num_quantiles):\n",
-    "                q = self.quantiles[i]\n",
-    "                \n",
-    "                # Get output layers \n",
-    "                output = tf.layers.dense(self.layer1, 1, name=\"{}_q{}\".format(i, int(q*100)))\n",
-    "                self.outputs.append(output)\n",
-    "                \n",
-    "                # Create losses\n",
-    "                \n",
-    "                error = tf.subtract(self.y, output)\n",
-    "                loss = tf.reduce_mean(tf.maximum(q*error, (q-1)*error), axis=-1)\n",
-    "\n",
-    "                self.losses.append(loss)\n",
-    "\n",
-    "            # Create combined loss\n",
-    "            self.combined_loss = tf.reduce_mean(tf.add_n(self.losses))\n",
-    "            self.train_step = tf.train.AdamOptimizer().minimize(self.combined_loss)\n",
-    "\n",
-    "    def fit(self, x, y, epochs=100):  \n",
-    "        for epoch in range(epochs):\n",
-    "            epoch_losses = []\n",
-    "            for idx in range(0, x.shape[0], self.batch_size):\n",
-    "                batch_x = x[idx : min(idx + self.batch_size, x.shape[0]),:]\n",
-    "                batch_y = y[idx : min(idx + self.batch_size, y.shape[0]),:]\n",
-    "\n",
-    "                feed_dict = {self.x: batch_x,\n",
-    "                             self.y: batch_y}\n",
-    "\n",
-    "                _, c_loss = self.sess.run([self.train_step, self.combined_loss], feed_dict)\n",
-    "                epoch_losses.append(c_loss)\n",
-    "                \n",
-    "            epoch_loss =  np.mean(epoch_losses)\n",
-    "            self.loss_history.append(epoch_loss)\n",
-    "            if epoch % 100 == 0:\n",
-    "                print(\"Epoch {}: {}\".format(epoch, epoch_loss))\n",
-    "            \n",
-    "    def predict(self, x):   \n",
-    "        # Run model to get outputs\n",
-    "        feed_dict = {self.x: x}\n",
-    "        predictions = sess.run(self.outputs, feed_dict)\n",
-    "        \n",
-    "        return predictions\n"
+    "        # minimize quantile error\n",
+    "        q_error = tf.subtract(y_true, y_pred)\n",
+    "        q_loss = tf.reduce_mean(tf.maximum(q*q_error, (q-1)*q_error), axis=-1)\n",
+    "        return q_loss"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**General function for creating the Milti-Quantile Neural Network (MQNN):**"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Instantiate model\n",
-    "quantiles = [.1, .5, .9]\n",
-    "model = q_model(sess, quantiles, batch_size=32)\n",
-    "\n",
-    "# Initialize all variables\n",
-    "init_op = tf.global_variables_initializer()\n",
-    "sess.run(init_op)"
+    "def build_mqnn(quantiles:list, training_x_values:np.ndarray, internal_nodes:list = [32, 32],\n",
+    "               model_name:str = \"mqnn\", optimizer=None, input_normalization:bool = True):\n",
+    "    \"\"\"\n",
+    "    Builds a MQNN\n",
+    "    :param quantiles: List of floats with quantiles to be trained. E.g. [0.25, 0.50, 0.75]\n",
+    "    :param training_x_values: 2-D numpy array with form [n-records, n-features]. NO categorical data expected.\n",
+    "    :param internal_nodes: List of integers describing internal nodes. E.g. [24, 12] means: two dense layers with 24 and 12 nodes, respectively.\n",
+    "    :param model_name: String to be used as model name. Default: 'mqnn'.\n",
+    "    :param optimizer: A tf.optimizers.Optimizer object to be used as optimizer. If not given, uses default Adam with training step of 0.001.\n",
+    "    :param input_normalization: Boolean. If True (default) includes a normalization step built in to the NN.\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    input_dim = training_x_values.shape[1]\n",
+    "    output_dim = len(quantiles)\n",
+    "    \n",
+    "    # define normalizer\n",
+    "    normalizer = preprocessing.Normalization()\n",
+    "    normalizer.adapt(training_x_values)\n",
+    "    \n",
+    "    # build model's node structure\n",
+    "    inputs = layers.Input(shape=input_dim)\n",
+    "    mdl = normalizer(inputs)\n",
+    "    for n_nodes in internal_nodes:\n",
+    "        mdl = layers.Dense(n_nodes, activation='relu')(mdl)\n",
+    "    outputs = [layers.Dense(1, activation='linear', name=\"q%d\" % q_i)(mdl) for q_i in range(output_dim)]\n",
+    "    del input_dim, output_dim, mdl, normalizer\n",
+    "    \n",
+    "    # define optimizer and loss functions\n",
+    "    optm_func = tf.optimizers.Adam(learning_rate=0.001) if optimizer is None else optimizer\n",
+    "    loss_func = MultiQuantileLoss(quantiles=quantiles)\n",
+    "    \n",
+    "    # build and compile model\n",
+    "    model = tf.keras.models.Model(inputs=inputs, outputs=outputs, name=model_name)\n",
+    "    model.compile(optimizer=optm_func, loss=loss_func)\n",
+    "    \n",
+    "    return model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Instantiate model:**"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "quantiles = [.1, .5, .9]\n",
+    "model = build_mqnn(quantiles, times, internal_nodes=[32, 32], model_name=\"mqnn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Train model:**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Epoch 0: 1.28651762008667\n",
-      "Epoch 100: 0.566359281539917\n",
-      "Epoch 200: 0.4066397249698639\n",
-      "Epoch 300: 0.33803483843803406\n",
-      "Epoch 400: 0.30299827456474304\n",
-      "Epoch 500: 0.2755032181739807\n",
-      "Epoch 600: 0.25843241810798645\n",
-      "Epoch 700: 0.25172367691993713\n",
-      "Epoch 800: 0.24871711432933807\n",
-      "Epoch 900: 0.25110912322998047\n",
-      "Epoch 1000: 0.2475467175245285\n",
-      "Epoch 1100: 0.2458878606557846\n",
-      "Epoch 1200: 0.24449209868907928\n",
-      "Epoch 1300: 0.24454854428768158\n",
-      "Epoch 1400: 0.24357259273529053\n",
-      "Epoch 1500: 0.2434576004743576\n",
-      "Epoch 1600: 0.24177248775959015\n",
-      "Epoch 1700: 0.24332064390182495\n",
-      "Epoch 1800: 0.2407195121049881\n",
-      "Epoch 1900: 0.23958206176757812\n"
+      "Wall time: 5.6 s\n"
      ]
     }
    ],
    "source": [
-    "# Run training\n",
-    "epochs = 2000\n",
-    "model.fit(times, accel, epochs)"
+    "%%time\n",
+    "history = model.fit(\n",
+    "    times, accel, \n",
+    "    epochs=2000,\n",
+    "    batch_size=32,\n",
+    "    verbose=0\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Plot graphic:**"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXYAAAD8CAYAAABjAo9vAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAIABJREFUeJzsnXd81dX9/5+fu2/2guzFCmQACREFFBRkONBItVW+Vm1tHXW1VRS1dVUrRb9frb/aOuqstVKR4QRUQKZCQgQSwk6A7EX2uuP8/rjZudn3Zp7n45EH5NzzOef9SfJ5nfN5n/d5H0UIgUQikUhGDqrBNkAikUgkjkUKu0QikYwwpLBLJBLJCEMKu0QikYwwpLBLJBLJCEMKu0QikYwwpLBLJBLJCEMKu0QikYwwpLBLJBLJCEMzGJ36+fmJiIiIwehaIpFIhi0pKSnFQogx3dUbFGGPiIggOTl5MLqWSCSSYYuiKGd6Uk+6YiQSiWSEIYVdIpFIRhhS2CUSiWSEMSg+dolEMriYTCays7Opq6sbbFMkdjAYDISEhKDVavt0vRR2iWQUkp2djbu7OxERESiKMtjmSFohhKCkpITs7GwiIyP71IZ0xUgko5C6ujp8fX2lqA9BFEXB19e3X29TUtglklGKFPWhS39/N1LYJZI+YLKa+OT4J2SUZAy2KRJJB6SwSyS9JLM8kxs/v5Gn9j7FTV/cxP8m/y+15trBNmvY8ctf/pKxY8cSGxvbpry0tJSFCxcyceJEFi5cyPnz5wHYvn07e/bsaa532223sXbt2m77yc7O5tprr2XixImMGzeOe++9l/r6esfejB37XnvtNd5///1e2eoo+i3siqKEKoqyTVGUI4qipCuK8oAjDJNIhiImi4kHv3uQopoiVs9dzXUTr+Pd9HdZtnEZe3P3DrZ5w4rbbruNTZs2dShftWoVCxYs4MSJEyxYsIBVq1YBHYWzJwghWLZsGUlJSZw4cYITJ05QW1vLww8/7JB7aE17++666y5uueUWh/fTI4QQ/foCAoGExv+7A8eB6K6umTFjhpBIhiOvHHhFxL4bK7af3d5cti9vn7h63dUi9t1Y8djOx8T52vODaGHPOHLkyGCbIIQQIjMzU8TExLQpmzRpksjNzRVCCJGbmysmTZokMjMzhb+/vwgKChLTpk0TO3bsELfeequ47777xKxZs0RkZKT4+OOPO7T/zTffiEsuuaRNWXl5ufDy8hKVlZXinXfeEffcc0/zZ1dddZXYtm2bEEKIu+66S8yYMUNER0eLJ554orlOeHi4eOKJJ0R8fLyIjY0VGRkZdu178sknxQsvvCCEEOLWW29tti85OVnMnTtXJCQkiEWLFjXfa3vs/Y6AZNEDXe53uKMQIg/Ia/x/paIoGUAwcKS/bUskQ4kjJUd46/BbXDP+GuaFzmsuvyDgAtZes5Y3Dr3B24ffZlfOLh6+4GGujLxyWCxQPv1ZOkdyKxzaZnSQB08ujenTtQUFBQQGBgIQEBBAQUEBERER3HXXXbi5ufHQQw8B8NZbb5GXl8euXbs4evQo11xzDddff32bttLT05kxY0abMg8PDyIiIjh58mSXdjz33HP4+PhgsVhYsGABhw4dYurUqQD4+flx4MAB/v73v/Piiy/yz3/+s4N93377bYc2TSYT9913Hxs3bmTMmDGsWbOGxx9/nLfffrtPP6vOcKiPXVGUCCAe+MGR7Uokg43JYuIPu/+Aj8GHhy/o+BqvV+u5L/4+1ixdQ4hbCCt3ruTub+8mtyp3EKwdOSiK0uXgmJSUhEqlIjo6moKCAof2/d///peEhATi4+NJT0/nyJGWueqyZcsAmDFjBllZWT1u89ixY6SlpbFw4UKmT5/Os88+S3Z2tkPtBgduUFIUxQ34BPitEKLD8K8oyh3AHQBhYWGO6lYiGRBeO/QaJ86f4G/z/4an3rPTepO8J/H+Fe/z0bGP+OuBv5K0MYn74u9j+eTlqFXqAbS45/R1Zu0s/P39ycvLIzAwkLy8PMaOHdtpXb1e3/x/m6eiLdHR0R0WLSsqKsjPzycqKoq0tDSsVmvzZ02x45mZmbz44ovs378fb29vbrvttjZx5U39qtVqzGZzj+9NCEFMTAx79zp3PcYhM3ZFUbTYRP3fQoh19uoIId4QQiQKIRLHjOk2nbBEMiTYkJrDRS++x+sH/4m25gLOF0/o9hq1Ss3/TPkfNl67kUT/RFbvX83NX97MsdJjzW3OWbWVyJVfMGfVVjak5jj7NoYV11xzDe+99x4A7733Htdeey0A7u7uVFZW9qqtBQsWUFNT0xydYrFYePDBB7n33nsxGo1ERETw448/YrVaOXfuHPv27QNs4u/q6oqnpycFBQV89dVX3fbVE/uioqIoKipqFnaTyUR6enqv7qknOCIqRgHeAjKEEP/Xf5MkkqHBhtQcHl33IxXuHyDMbpSeu4JH1x3usRAHugXy6oJXWT13NbnVudz4+Y3c8+WzPLr+ADlltQggp6y2V22OJG666SZmzZrFsWPHCAkJ4a233gJg5cqVfP3110ycOJFvvvmGlStXArB06VLWr1/P9OnT2blzZ4/6UBSF9evXs3btWiZOnIivry8qlYrHH38cgDlz5hAZGUl0dDT3338/CQkJAEybNo34+HgmT57M8uXLmTNnTrd99cQ+nU7H2rVreeSRR5g2bRrTp0/vdaRPT1Dsvb70qgFFuRjYCRwGmt5pHhNCfNnZNYmJiUIetCEZ6sxZtZUCsQtj0MfUZt+MudIWbx3sZWT3yvm9aqusrowXk19k46mNWBt8qctbhqVmfPPnfWmzP2RkZDBlypQB62+osGfPHm666SbWr1/fLOJDFXu/I0VRUoQQid1d64iomF3A0F/6l0h6SW5ZFS7jt2KpC8JcGdOqvPebkbwMXjx78bN8tHUM+sD1uIS/SUPpLOoLrgbUfWpT0ntmz57NmTM9OoRoWCN3nkokneAXmIFKV0JD0QJaz12CvIx9btNfF0f16QdoKJmDzmcvxtD3QFWPAOlvlzgMKewSiR0sVgtu/tsR9YGYq1peh41aNSsWR/W53RWLozBqjNQXLqUubxlq15O4hL+Goikf1f52iWORwi6R2GFT1iaK67O5adLtBHu5omDzgz+/LI6k+OA+t5sUH8zzy+II9jJiKptJ7bnbUGlLcYl4FZU+l1qThRc2H3PYfUhGJ/KgDYmkHRarhdcPvc4Erwk8Ou8GHr/UsfOfpPhgkuKDiVz5BZbqSdScuQtj6Lu4hL9GzZk7yS3r+8AhkYCcsUskHfj6zNdklmdy57Q7USnOe0SafPXW+kBqsn6DsBowBK0l0EvntD4lowMp7BJJK6zCyuuHXme853gWhS9yal8rFkdh1Np2owqzJ/X516I25HFh/CGn9jtUiIiIIC4ujunTp5OY2BLBJ9P29h8p7BJJK74+8zUny046fbYObf3tCuCvSSTWcy7fFf6b0+Wnndr3UGHbtm38+OOPtN7XItP2OoCepIB09JdM2ysZilisFpG0IUksXb9UmC3mQbGhqKZIzP5wtvj5lz8XFqvFaf0MhbS94eHhoqioqEO5TNtrY1DT9kokI4WtZ7dysuwkz1/y/KAl7PIz+vHIzEd4fNfjrDm2hpsm3+T8Tr9aCfmHHdtmQBxcsarLKoqisGjRIhRF4c477+SOO+4AZNpeRyCFXSLB5lt/7eBrhHuEsyRiyaDasnTcUr44/QUvp7zMpSGXEugWOKj2OItdu3YRHBxMYWEhCxcuZPLkycydO7dNncFO2/vGG29gNpvJy8vjyJEjzcLeOm3vunV28x7apXXaXrAlJWsaxByJFHaJBPj27LccO3+M5y5+Do1qcB8LRVF4YtYTXLfxOp75/hn+vuDvzj2wo5uZtbMIDraFdY4dO5brrruOffv2MXfuXJm21wHIxVPJqMditfC31L8R4RHBlZFXDrY5AAS7BfNAwgPsytnF56c/H2xzHE51dXVzitvq6mq2bNnSfKi1TNvbf6SwS0Y9X2Z+yeny09wTf8+gz9Zbc2PUjUwbM43V+1dTUlsy2OY4lIKCAi6++GKmTZvGzJkzueqqq1iyxOYCk2l7+0+/0/b2BZm2VzJUMFlNXLP+Gtx0bqy5ek2PQhw3pObwwuZj5JbVEuRlZMXiqH6lGeiKU2WnuOGzG7g87HJWz1vtsHZl2t6RnbZXztglo5r1J9aTXZXNffH39VjUH113eMAOyhjvNZ47pt7BV1lfsf3cdqf0MZpoSts71EW9v0hhl4xa6i31vH7odaaNmcYlwZf06JoXNh+j1mRpU+bsxF23x97ORO+J/On7P1HZ0Dsfs2R0IoVdMmpZc3QNhTWF3B9/f4+jTjo7EMOZB2Vo1Vqemf0MxbXFvJzystP6kYwcpLBLRiU1phreSnuLCwMvZGbgzB5f19khG/05fKMnxPrFcvOUm/nv8f+SnC/XpyRdI4VdMir5IOMDSutKuT/+/l5d1zpxVxP9PXyjp9wz/R6C3YJ5eu/T1Fscn8RKMnKQwi4ZdZTXl/Nu2rtcGnIpU8dM7dW1SfHBPH9dNNe5H+MRzX9Y6n6i34dv9BQXrQtPznqSrIosXjv4mtP7kwxfpLBLRh3vpb9HpamSe+Pv7f3F5gaSjj7MS6anuVvzGf/P9BRJZe+D1dL9tQ5gVtAskiYk8U7aOxwtPTogfTqLv/71r8TGxhITE8PLL7esHci0vf1HCrtk1LAhNYdZqz/ljYPvoamNJ+OMW+8asJjhk1/C8a9g0bPwcCZMuwm+W0XhP67iqufXEbnyC6cfSv1Q4kMY1R78bN3viFz56bA8BDstLY0333yTffv2cfDgQT7//PPmpFwybW//kcIuGRU0xZ+XKDtRVA2U517au/hzqwXW3wEZn8Hi52H2feDiA0l/J3X6n/AoTOatut8zQznaHNv+hw2HmbNqq8PFftuRKsrPXY1Vm43GZ9ewPAQ7IyODCy+8EBcXFzQaDfPmzWtOprVx40ZuvfVWAG699VY2bNhAVlYWr732Gi+99FKbnZ07duxg9uzZjBs3zu6MeOvWrRgMBn7xi18AttwuL730Eu+//z5VVVW8++673Htvy5vb1Vdfzfbt2wG4++67SUxMJCYmhieffLK5TkREBE8++SQJCQnExcVx9OhRu/Y99dRTvPjiix1sSklJYd68ecyYMYPFixeTl5fnmB9qK4bO/mmJxInY4s9NuHrtx1wdibXBn1ps8efd+setVth4L6R9Apc/BbN+0/KZonDv0Vg8Gp7h79qX+Uj3LKvNP+MN09X8+/uzNO3rbhJfoN/++Bc2H6OmLBqDWzT6MV9jroyh1uTXs3uxw1/2/cXhbp3JPpN5ZOYjnX4eGxvL448/TklJCUajkS+//LL5FCWZtrf/yBm7ZFSQW1aL2uU0Kl0JprKZbcq7RAj44vdw8EO49DG4+Hd2284Q4VzT8BxbrIk8pv0Pb2r/D3eq2tRz1EYmm80K9flJIDQYAtcBwqmx9I5mypQpPPLIIyxatIglS5Ywffp01OqOOfAHO21vQkIC8fHxpKenc+TIkebPWqftzcrK6nGbrdP2Tp8+nWeffZbs7GyH2g1yxi4ZJQR5GSlx2Y+wGDFXxrYp75LjmyDlHZh9P8yz75cN8jKSU1ZLJS78xvQAt1k387jm33yue5zfmB4gTYxrrusI8W3qT5g9qC+8EkPgOrRe+xnLvD6119XM2pncfvvt3H777QA89thjhISEAMi0vQ5Aztglo4LfLYxE434UU0UcCC3Qg/hziwm2/AF8J8KCJ6CTmWPb2HaFdy1L+GnDE6gVK5/onuJm9dfQ6JRxxEam1v2Zyi7AXD0O/dgvuXO+X7/bHkgKCwsBOHv2LOvWrWP58uWATNvrCKSwS0YFQQF5KKp6PMV0FCDYy9h9/Hny21By0hYBo9Z2Wq39odTBXkZiLlzA9da/sMcaw7Pad3hZ+yq+WpNDNjK17U/Bq3o5Wo2VA9WO9dM6m5/85CdER0ezdOlSXn31Vby8vACZttch9ORgVEd/ycOsJQPNc98/JxL/lShqTbU9u6CmVIhVEUK8e7UQVmuf+lx/IFvM+fPX4oXHfiXMT3qJ8hemC1GQ0ae2uuOtw2+J2HdjxZasLT2qPxQOsx4Mdu/eLcLCwkRKSspgm9It/TnMWs7YJSMeIQTfnfuOiwIvwqAx9OyiHS9C7XlY9FynLpjuSIoPZtejl/PQc2+ivnUjHqIK3rwMDq7pU3tdcUv0LUzxmcKff/gz5fXlDm9/pCDT9kokI4STZSfJrc5lXmjXi4sbUnOYs2or8x59G9Pe1zgTdh0E9i7lQKdEzoW7dkJQvC0e/rMHwFTX/XU9RKPS8MycZzhfd57/Tf5fh7UrGZ5IYZeMeL7P+x6Ai4Mv7rRO6wM0HtH8hwah5ueZCx276cc9AG751BYymfIuvHsl1JQ2Dyj93cg02Wcyt8XcxvqT69mb233UhRiE09MkPaO/vxsp7JIRz/78/YS6hxLgGtBpnaYDNBKVo1yp3sdr5qWcNXk6/gANtca2yelnH0D+YcpfW8yL63Y67ESmu6bdRbhHOE/vfZoaU02n9QwGAyUlJVLchyBCCEpKSjAYeug2tIOMY5eMaKzCSkpBCpeHX95lvdyyWhSs/EH7AXnChzctVzWXO4UpS2H5GnT/upH3lKe4mcfIwxdo2cjUl12kBo2Bp2Y9xS82/4JXf3yVFRessFsvJCSE7OxsioqK+nUbEudgMBia4/r7ghR2yYjmxPkTVDRUkOjf9fm/QV5GEiu+ZrrqNL9vuIs69M3lTmP8fH5ev5K3dav5WP80/9PwGGeE7a2iPwNKYkAiN0y6gQ8yPuDCwAuZGzK3Qx2tVktkZGSf+5AMbaQrRjKi2Z+/H4ALAi7ost4jl4fziHYNh60RrLfafPEDcYBGnud0ljc8jgt1fKx7hjDFti2+vwPKQ4kPEeUdxUPfPdT8M+gKR/n5JUMDhwi7oihvK4pSqChKmiPak0gcxf78/YS4hXTpXwe4pupjgpQSXjPcDqh6toHJAaxYHMUpzUR+1vAEOkz8Q/synlpLvwcUF60Lf1vwN7z13vxy8y+5+cub+cfBf7Avbx+15rZvA60Xjpv8/Cs+Pkj8M1uk0A9THOWKeRf4G/C+g9qTSPqNVVhJKUxhfuj8riuWnYVdL0HMdbx6Q++OyusvTQPHC5t1PFhxN2/pXmRDxOdExl/T77bHuozlk2s+Yd2JdXx66lP+8eM/EAg0ioaJ3hOJ9o0m1i+WF7+todbkBbQk4TJZBedrTIBjM1NKBgaHCLsQYoeiKBGOaEsicRQnzp+gvL6cxICu/ets+SOgwMI/DYhd7UmKD24UzPnwtYnI3X+Fw4sg7vpur+0ON50bt8Tcwi0xt1BeX87BooOkFqaSVpzGljNb+OTEJzAG3Hw1WOsDsdSGYKkLwVobgrVhDE0v9f1Z0JUMPHLxVDJiSS5IBuh64TRzBxzZAJc9Dl6hA2RZF8z/I5z9AT69HwKmwphJDmvaU+/J3JC5zYupQgjOVZ7j+rf/S7n1FCpDDlqvFHQqWwy8sOiw1AVjrQvGUhdKXnUwQogu0+hKhgaKo+JYG2fsnwshYjv5/A7gDoCwsLAZZ86ccUi/Ekln/G7b78gozWDTTzbZr2Axw+uXQEMV3LMPtE6MgOkN5Tk2u9z84Vffgs7Fqd01+dhrTRbAikpXhMqYjdqQjdqQg8qQi6KypaZ117kT4xtDrF9s87/+Lv5S7AcIRVFShBDdvIIO4IxdCPEG8AZAYmKi3BUhcSpWYSW5IJl5IV2kEUh+GwqP2DYLDRVRB/AMhmVvwAfXw1cr4NpXndpdi5//GLlltXioQ6iuCqC+vOnkIQtG1yJ+Mkugdc0hvTidd9PexSxsYu9j8Gkj9NG+0fgZh1cK4ZGGdMVIRiQny05SVl/WeZhjdQlsexYi58HkqwfWuJ4w4XKY+xDseAHC58D05U7trsXPb2NDak6z0Ad5ubFi8Yw2n9db6jlWeoz0knTSitM4UnKEndk7EY155wNcA9oIfYxvDJ56T6feg6QFhwi7oij/AS4F/BRFyQaeFEK85Yi2JZK+kJzf6F/vbOF027NQXwVX/KXP2RudzqWPwtnv4fPfQ+B08I8esK7bC3179Go9U8dMZeqYliRpNaYaMkozSCtOI70knfTidL4923LuZ6h7aBs3zhTfKbhqXZ16H6MVR0XF3OSIdiQSR5FckEyQaxDBbnbEKe8gJL8DF94FY6cMvHE9RaWGn/wTXrsEPr4Vfr0N9G6DbVWnuGhdmOE/gxn+LYdHl9eXc6TkSLPQHyw6yKYs25qHgsI4z3HE+MU0h15GeUf1PLWypFOkK0Yy4rAKK8n5yVwScknHD4WArx4BFx+4dOXAG9db3ANs4v6vJNuh2te9PnTfMOzgqfdkVtAsZgXNai4rqS2xCX2j2O/O2c2npz4FQKNomOA9gRjfGGL8YojxjWGi90S0qs5PsJJ0RAq7ZMRxquwU5+vP2w9zPL4Jzu6FpX8Fo9fAG9cXxs2zuWW2PWfzt8+4dbAt6he+Rt8OYZcFNQXNQp9eks7XZ762xdgDOpWOKJ+oZrGP9Y0l0jMStUrdVTejGinskhFHU/y63YXT7/8OHiEw/eYBtqqfXPIgnNkDX66A4AQIiBtsixyGoigEuAYQ4BrAgrAFgE3ss6uym4U+rTiNT099ykfHPgLAqDEyxWdKs9DH+MUQ5h4mwy4bkcIuGXHsz99PoGtgR/96fpptQ9LlT9vyojuJthElRlYsjur/jk2VGpa9aYtv/++tcMd2MHg4wtwhiaIohLqHEuoeypLIJYDNxZZVntXsxkkrTuO/x/7Lvyz/Amwx9tG+0c1CH+sbS4BrwKgUeynskhGFEIKUghTmBM3p+ED/8BpoXSDhFqf133azj4PzrLiNgZ+8Be8thc/uh+vfGTB/u1MGq16iUlSM8xrHOK9xLB2/FACz1cypslPNQp9eks57R97DbG2JsW9amG2KyBkNMfZS2CUjiszyTErrSjuGOZrqIH0DxC6zLZw6iaaTmFrj0DwrEXNg/h/g26dt/vaZv+5/m93g1MGqn2hUGqJ8oojyiWLZxGWALcb+xPkTzUKfVpzGntw9WIUVsCVHaz2rj/aNxsswTNZbeogUdsmIosm/3jrkDoDT26ChEmKuc2r/nR2Q4dCTmOb81rYAvPkxCEm0HZDtRJw+WDkYvVpPrF8ssX4t2U1qTDUcLT3aZkPV1nNbmz8PcQtp46+f4jMFN93QDS3tDinskhFFckEyY4xjCHMPA1pcCL+vfpWFaje2lU/gWif2H+RlJMeOiDv0JCaVyhb2+Fqjv/3OHU6N8BmQwcrJuGhdSPBPIME/obmsoqGCjJKWDVWHiw6zOWszYIuxj/CMaBb6GN8YJvtMHjYx9lLYJSOGJv/6DP8ZKIrS7EIwm+q5XJ/CZnMiT2w4ilBpnTbTXLE4qo3bApx0EpOLD9zwDrxzBWy8x5bvxkn+9t4OVt354wfLX2+/3wu5MPDC5jqldaUcKTnSLPbf533PZ6c/A0CtqJngNaFZ6GP8YpjkNQmtuvsY+4G+ZynskhFDdmU2hTWFzfHrTS6ES1RH8FRq+Mo6k1qrc10I7RNqOfUhDp1pi/DZ8jh8/w+Y9RvH90HvBqvu/PGD5a/vab8+Bh8uDr6Yi4Mvbi4rrClskyZh69mtrDuxDgCtSkuUd1QbsR/nOQ6NStPrvh2JFHbJiKG9f73JVTBHlUa90LDHGtOmvKf0drbVXZ4VhzLrHlt8+9d/tAl9SLcZXXtNbwar7vzxg+Wv70+/Y13GMj9sPvPDbCdxCSHIqcpps6Hq89Ofs+bYGsAWYz/ZZ3Kz0K/6popakyutTyJ19j1LYZeMGJILkvHWezPeazzQ4kKYrUonVUykDn1zeU8ZyhEhgM39kvQqvD4XPr7N5m93QtRPTwer7vzxg+Wvd2S/iqIQ4h5CiHsIiyMWA7YY+zMVZ5oXZtOK01h7fC0fZHwAY8HN14ClLhhz+XRM5Rf0ue+e4pDDrCWSoUBKQQoJ/gnN8esrFkfhr60lVslij8U2W++tv7urmd6QwegNN7wLlfmw4W6wWgfNlM4Gzaby7j53Fs7uV6WoiPSMZOn4pTwy8xH+deW/2Lt8L2uXrsVQdhOmimkoqnoUbZnD+7Zrj9NalkgGkPzqfHKqctrkh0mKD+aVWdWoFMFeazTBXkaeXxbXq5n2sIkICZ4Bi5+D45tIW/ssc1ZtJXLlF8xZtZUNqTkDZsaKxVEYtW1zuLQeTLv7fLDscgZNMfaPz70VVcn11GTdS0PxwoHp22ktSyQDSGv/emuf+GrXzcxQG/n4T/eBRtfrdgckfNFRzLyDnIPfMDn9JQIa3MghasBdR9354wd0cbkXdo20vh125mlvSExMFMnJyQPer2Tk8tSep9iStYWHJn/E4+uPNLtPNuseplDxpSTpP316kNr72ME22+rtzH+gWPT8Z7xR+yB6xcSV9X/mPLZ8MsFeRnavnD/I1kn6S0/PPJWuGMmIIKUghXj/eP53y8lmEfajnChVNrvM0X32iSfFB/P8sjiCvYwo0Cd3ThMbUnOc7iI5Ua7iHtP9+FDBS9p/oMb2sxhyriOJUxlWrpjOws6GQoKintIXW4fT/Q0GxbXFZFVksWziMr5sJWCzVOkA7LHG9EvYHBG+OFDRNUFeRtLLInnKfCvPa9/iNV7mXtN9+Hn1/bzRobrhqLd2jiaGjbB39mAknynlk5ScoRuO1oq+PNxDPtxuCJBSkALY/OtBXsXNPvFZqnQqhAvpImLQfeIDFb/dtJnoP6YFaLDwtOY9DujvpM4lBv7zT1uqX70HaA2gMYJGD1ojaAy2r3bl205V8s+tZ1DMavzQUVlWzRPrqkEIkhJChszf51CxY6gwbIS96cFQGc6iqMyAoAHBR4ePInQCtc4KigAEJgR//i4DF+8YrMJq+8KKEKLl+3ZlFmHhUHYZ3x7Np6K2AQ+jhrmT/JgS6Gb3+qP55fyQWUJVvQk3vYoZEd5E+hmxCiuCdv00ln11OBcxxoyBFlsFgqf3qfi21BeLsLSu4wEhAAAgAElEQVTpRwhB8pkSCDJjRIDVgKkijtqKqUM2AdNgkJyfbDt4wXcKKxYXNj/gs1VH+N46Bb1W6/Soi+4YqOiapr+Jpz5N51+1izgpgrlGd4CFShGUnYG6CqgvB3M9mOu6be8y4DI10O6wIuunCuYv9Mwza9iq0lGv01KHjjq01KODzwxwNLjbgQON3va91tCqThflnZyaNNwSlTmbYSPsTQ+AV+jbmDTd/0HWAg9+14eOGic09cDX+bavNggFgQJCARcFrYtCvVDYU6Cwt0CFEAqKogIUrFZbfCuobKHFGgW1RkEI2+cIBVCoR6GgxoxKUaFSVCiKQlm1mZyyOurNAttSiAqVrhhj0FqsYzdRVHwpH6dE8vLXmaP+1TOlMIXpY6ajbZUD5v1NO4moL2C95mqev8rxC51V9WaKKusJ9TaiUXe/VDXQ0TX1Zlss+15rDHvrYnim0M6Cr9UKlkaBN9WBudYm+KZaW5m5jl+/tQs9DegxYVAaMDT+X6804GY1o7bWY6ABg9JYhwYMmNCbq6DsrN02acyV3idUGjuCb+D/1dRSp9VRh456GgcZoaOhSgtbtvVtEGkq1+ib8/A0uXtyympRKwoWIQgegs/esBH2pgdjdWEJ7kqVTeoEqGwyiwpQC1AQqLBNiFWAuunzxu+bPm/6XoVorqtCIKwKVtSACisqhFBhRY1AhQUVVqHG3PiZGTUWWn+vYEHBLBQsjfWb6lhQGuuqsQhV4+e2a416PT+NiLDNRlQajhbW8HVGMbUWjzbtnxPT2Kb3RTdmK/qAz3n6x53UMx/BjFH76llWV8aJ8ydYEr+kuSwpPpgkLLARfvfrX4G/434e5TUm/rAxjc8O5gIQF+zJ35bHE+7r2uV1A5YcjF7MXlUqUBltItbJ+HLEA7sDklpRsJg7j6gL9jKy++5OonAsZvuC38ng0pNyc2EOGnMdvlQ0Di4N6FUmXBQT7NvRo7eTLtEYaFB0zGpQ86HQUqdrNYhU6zBt0JO934+QMT5tB4j2byljp9hSPziZYSPsKxZH8ds1P/JcxWPoMKHBigormkbZ1Citv7f9a/veilEjmDPOCzetgpsO3LQKrlrBhpRz1NbXo8HaKL9W1Iql7fet+lAj0CiN/XVRR6uYMbb6rEN9VSu7EbgpQPI220xGWJhsNTPZNtJ04E3Tlfz57O14eJ/F5PEFhsD16Hx2UnPmbmpNrh0e3pG2oNT+fq6+qBSwk389cwe4+NkeJAfx/ekSfr/mRwor6/n1JZEEeBr56zfHufqVXay+fipXxAV2eu1AxjI70u3T2YDUfuBoTbcDlloDanfQu/fans7I7S4sVYhG91MPBw5TbUt9k63epz+cxGypQa+YWgYPTLgptRhEBZa8PKhWtb22/dtJ4i+lsLcmKT6Ypz9LJ7Omk4enq3D8BticqaGyvv0r4GRHmdcnvF20PLk0psPDHbnycxREq8HJggYLD2jW8WvNl5hRs/r8TYjzd6NxO4Ih5N/o/L6hvuDaNg/vSFtQsnc/Hxzcis5bR5xfq8OdhbAJe+QlDkll22C28vI3x/nHd6eI8HXlk7tnMy3Ulv98UbQ/9/4nlbv/fYDbZkfw6JWT0Wvs+4EHKjmYI90+nQ1ITe6I9qgVZVBi/LsdOBXFNnPW9j2f+oqtX3QpMwqQ+eRVbQst5lYDSK3t7WgAGDbCDvDk0pgOo3JPaNqc0WC2UlbTQGlNA6XVDdz771RKaxqcZG33uOg0dh+AIC8XcspqaWg3ZX/afAt6TNyt+YwsYyxrKuMwV8VgKpuJ1vsHTOdnEegS3lx/pC0o2bsfoT+NqAtDp261q7TkFFTmQuTcfvdZWWfi5rf2cfBcGTdeEMofr47GVd/y2IT6uPDxnbNYveko/9yVScqZ87y6PIEwX5d+991XHO326WxAGmobt5w9cHY2YLb+vANqDajdQD+wpzENqw1KrTeLgG2EbI1WpaBVty1t/Qet06gY62FgcoAHs8f78cTS6A75I5pQgDnjfTBouv8RaVR9mxXaZtCHWL3pKG/uOM3alGy2Hi3ghsQQ9Hb7VfiL8gvKPKP5E68yXlsCQEPR5WDVYgz4qs3DO2zynPSQDnar6lAZcqmtCG9bntm4ah45r1/9CSF46OODpOWU8+ryBFb9ZGobUW9Cp1Hxh6ujeePnMzhTUs1Vr+zkq8N5/eq7PzhyU9Vg9jHUsJdvpomByHfTG4bVjB3ajsr2/MfQcz9m69e3zla5W/fhadSiKFBWY+rQduvV8p6iUSl8k1HI+eoGzNbuUzu4aNU8ujQOrwkfwuvzWOv7BtfV/pEz5W4YqhdT7/EpY/3PADabhlWekx7Q/n7UxiwUReClaudSy9wBHsHgM65f/b2+4zSb0wv4w1VTuGpq5/7zJhbFBPBFoEePXTPOZCDcPgOad34I0BO9GCrIXDFOwF5+kfa0fm0VQlBZb+Z8tc1FdL6mgdJqk+37mgZKqxoorqrnu+NFxIV48t4vZ+KRuQnW3Awz74QrV9NgaeCaDdfgonXh46s/Rq1SD7s8J93R/n50Y75C57uLJ+I+4aczbDnYsVrhxQkwcRFc91qf+9pzqpib//kDS2IDeHV5SyrgntBgtrLqq6O8vTuTqSGe/O2mwXXNSEYOPc0VM+xm7MMBews5l00ew7ajRXbfJBRFwcOgxcOg7TJsblNaPvd+eIAH/pPK27ddjXLRPfD9qxA+C13MdTyQ8AAP73iYnTk7uTT00kHNaOcM2t+Pi8cZgl2jWkQdoPAI1JT0y7+eX17H/f9JJdLPldXXT+uVqIPNNfPE0mguHOfDQx8f5Kr/t5MXrp/GktiAPtskkfQGOWMfZry/N4snNqaTND2I1MxCXqp9jChVDtuv+JZFF0zi8o8vJ35sPC9f9vJgm+pUakw1zPnPHG6NuZXfzvhtywd7/w6bH4XfpoFXaK/bbTBbufGNvRzLr2TjvXOYMLZ/IXnnSmu498MDHMwu5xdzInj0iinoerBu4wyGc+jrcLPdbLGSV15HVkk1WSU1nG38d/Z4X34xJ7LP7coZ+wjl5xeF83FyNht+tG2QeVa5mXX6p/j2izWYdHdy9bir+TDjQ0rrSvExOP6ItKHCwaKDmIWZxIB2f+OZO2y+9T6IOsBzXxzhwNkyXl2e0G9Rh8aombtm8/xXGbyzO4sDZ87zt+UJhPoMrGtmOIe+DoTtfRk46kwWss/XcKakpo14ny2t4VxpTZt1M51GRbiPCwlh3g6xtzuksA8zFEWhuLK++fuDYjzlwoULrQd5YfMx3r0zifePvM8Xp7/g59E/H0RLnUtKQQoqRcX0MdNbCi1mOLMbYpf1qc0NqTm8t/cMv7o4skeLpT1Fp1Hx5NIYLoz0ZcXag1z1yk5euGEai2MGzjUznENfnW17VwPH5dH+nCmp5myTeJdWk1VsE+/c8lpaOzzc9BrCfV2IDvRgSWwAEb4uhPm4EuHngr+7AVUfo+f6ghT2YUh+Rcv2aAtqdltjuVh9mJVlNUz0nkiMbwwbTm7g5ik399o/PFxILkhmis8U3HS2+OANqTl8/tVn/LOhgicO+ZIQktOrh/5ofgWPrjvMzAgfHrnCORvXlsQGEBPkwT0fHuDOf6Uwb9IYThRUklde53T3wnAOfXWm7UIIVn111O7A8fv//kj7YDVfVx1hvi7MjPQhzMeFCL9G8fZ1wcdVN2SeNynsw5D2YX87rXFcqd7HRR627fVJE5J47ofnyCjNINo3erDMdBr1lnoOFx3mxsk3Ai0zrtusqaCFLysn8HEPXtXbJHRSKbjq1PxteTzaHiT16is218wsfv1eMt8dL2oud7ZrZDiHvvbXdiEEhZX1ZBVXc6a0hjPNfu8askqqqayzn5TMKuDhJVGE+7gS7utCuK8L7gZtv+5loJDCPgxpv7Nwp9W2nf7RSTa/+xWRV/DC/hfYcHLDiBT2w0WHabA2NB9c3fSqPlubxlFrKMV4Qjev6u1fvy1WQZ3Jyp5TJU53Teg1ak4VVXcod6ZrZCCTkDmantjeerHyTElb8T5TWk2dydpcV61SCPE2Eu7ryvRQLz79MZfyOlOHfoO9jPzm0gnOvTknIYV9GNJ+o0S2GEuxPpSp9QcA8NR7siBsAV+c/oIHEx9Er9YPprkOJ6UgBQWFBP8EwPZKrsPEBapjfGhZ0Fyvq1d1e37bBot1wHzOndnWmw1uvWE4h7422bh601Fyy+vwcdUxb9IYUs+eZ31qjt3FSr1GRZiPC+G+rlw80c/m7/a1uUyCvIxt3spmhHsP20GvMxwi7IqiLAH+ii0d/z+FEKsc0a6kc5p2/VmsgoQ/fc1x1xn4ZW2xZZXT6EmakMRXWV+x7dw2lkQs6b7BYURyQTITvSfiqbcd9xbkZSSkPAODYmKPNaa5Xlev6oPtc+4q78g9Hx5gWXwwcyeNcahbaDjsFK2uN7edcbdarMxrXFsqrW5gfWqO3cXKcF+b26Q3i5XDedDrjH4Lu6IoauBVYCGQDexXFOVTIcSR/rYt6R61SmH2eF82Zk1mtnkDu7Z9ySMpnuSWVeM20ZOHN73F3VmWEfHHCmCymjhYdJCkCUnNZSsWR5Gz/gMsQmGf1bbw2X7G1T6czcOgodyOb3WgfM723At6tYqZkT7sPVXCF4fy8HXVsXRaEMsSgokL9uzzwtxQigEXQlBWY2rxdRfbXCU2Ma+huKq+Tf3Wi5VNfu5wX1fCfRy7WDkcBr3e4IgZ+0zgpBDiNICiKB8B1wJS2AeIORP8WJU2gef0Kg5+t44c842AivqyBHS+20FTTk4ZwyZuuSuOlByh1lzb7F8H2/2U7Mzk6PkJVOLaIXeHvXA2e3IwkK/fXc0STRYr3x0rYl1qNh/+cJZ392QxfowryxJCuHZ6ECHePY+BH4z4dXuLlU3Cfaakmop2A2qgp4FwXxcWTB5LuJ/LsFysHGo4QtiDgXOtvs8GLnRAu5IeUttgoQoXDoiJXKI6zAvYokVMZTPQ+21D63mAhpLLhk3cclc0HVzd5F8HoL4K37JD+M65j8zLr+pwjd10v4CLTo23i27QZrKdzRK1ahWXR/tzebQ/5TUmvjicx/rUbF7YfIwXNh/jwkgfrosP5oq4QDyNXQufs2LA7S1WNon32dKaNn22X6xsmnVH+LoQ6uOCoZOMiZK+M2CLp4qi3AHcARAWFjZQ3Y4K3tmdCcBOSxy/03yCNxWcxwNh8sNcE4HWM4WGkksBZVjELXdFcn4ykZ6R+Bn9WgrPfm87qaaT/DCd3XNtg4Ujz3RyfNsQwdNFy/ILw1h+YRhnS2rY+GMO61NzWLnuME98ms7lU8ZyXXwI8yaNsZuqoD9rCfVmC+dKa1uJdtMMvGeLlU3+7vaLlRLn4whhzwFa798OaSxrgxDiDeANsOWKcUC/kkbyym2LSj9Yp6BSBNNUp9hujQfAVJaIMWgtauMZLLURwyJu2R4bUnNYvTmDirH70NXNYENqqw1ImdtBrYPQi+xeO5xjuFsT5uvCfQsmcu/8CRzKLmd9ag6fHczly8P5eLtouXpqEEnxwSSEeTX7nru799aLle3dJu13VrrrNYT72RYrr4gNaPF393KxsiuG0nrAcMYRwr4fmKgoSiQ2Qb8RWO6AdiU9pOnhTRcRWIXCVCWT7diE3VwRhwj4FI1XMjrz+GEZwtXkJ65Xn8VVXU9FWVhbP3HmDgiZCTr7vufhHMNtD0VRmBbqxbRQLx6/ago7TxSxPjWX/yaf41/fnyHc14Wk6cEsnRbIg4sm8di6w9SZW8VxKwo6jYrEZ7+xu1gZPgCLlfYYzvlshhr9FnYhhFlRlHuBzdjCHd8WQqT32zJJj1mxOIqVnxyi2mzklAhiquoUWMBFq0KvdaO2Ig6dx2H+ePEfhuUD0uQn1rrZXE6WmkjM5kY/cZQR8g7BpY92en1SfDBWIVix9hAWqyDI08DDSyYPy59Fe7RqFfMn+zN/sj+VdSY2peWzPjWHV7ae4K/fnsCgVdFgsba5xt2gwd9Dz8wInyG1WDmc89kMNRziYxdCfAl86Yi2JL2n6Y9+xdqDHBKRzFOn8/J100hKCAEgpcCX2zbdht4zDRjfRUtDkyZ/sNr1NNYGH4TZs6X8zG5AdJt/PcDTgMUqeOln07guPsTZJg8K7gYtNySGckNiKHnltXx3rIiThVUYtGom+rsxyd+dSD/XIbtYOdh7C0YScufpCCEpPpiM/ArS94znJ+wiaULLYlXC2ATC3MPYcHID1064dhCt7Bs2V1M1amMWlqopbco5/SVoXSB4RpdtfLTvHB4GDVfEOi5r41Am0NPIjTOHV5DCSFkLGQrIpeoRxKxxvvxobkzin5vaXK4oCtdOuJbkgmTOVZ7r5Oqhy4rFURhdS1BpajDX2O6v2UeeuQPCZ4NG1+n156sb2JSWz7KEkCE7W5XYPyx6OK+FDCZS2EcQU0O8OCLCsSrqNsIOcM34a1BQ2Hhy4yBZ13eS4oNJusgW+WOtiSTYy2g7t3WCGoqPdeuG+TItjwaLlRsSR6YLZqSQFB/M88viCPYyokDL71n613uNdMWMIHxcdfh5e5FrCSeknbAHuAYwK2gWn5/+nHum3zNk8kb3FJPuJP4u/nz9zM9bbD/0se3fboR9c3pBc04RydBmpG3tHyzkjH2EMTXEk4OWSNuMvd15tleNu4qcqhwOFh0cJOv6hhCClIIUZvjPaDsgZW4HgxcETO302oo6E3tPFbM4JmDYDWYSSV+Rwj7CiAv2Ym9dGNSUQHlbf/r80Pno1Xq+zBxeAUxnKs5QXFts/3zTiItB1bnffNvRQkwWweIYfydbKZEMHaQrZoQxNcSTr6zjbN/kpoJXS2SEm86NeSHz2Jy1mSjtzfzflpPDYodfU36YGf6tIl/OZ0HZWZh1X5fXbkkvYIy7nvjQgTlEuL/InZcSRyBn7COM2CBPjoowLIqmwwIqwJWRV1JaV8ofN20gp6wWQcsOvw2pHTJBDAmSC5LxMfgQ6RHZUnj6O9u/XfjX60wWth8rZGG0/4AeJNxXmnZeDpffi2ToIoV9BLEhNYcrX9lJA1qOWkMpPPZ9hzpzgueAVYfFeLhNedMOv6GIff/6DnDzhzGdh8LtPllMdYOFxTEBA2Bl/+lq56VE0huksI8QWs/2AA5aItEXHmLDgew29QwaA+aqiWjcM7Alr21hKO7wy6nKIa86r03+dYSwCXvkXOhiQXRzej7ueg2zxvkOgKX9R+68lDgKKewjhPazvUNiHJ5KNR9u+q5DXTfrdFTaclSGtq/4Q3GHn13/etExqC7s0g1jtlj5JqOQyyaPtZvOdijS2c9/KP5eJEOb4fEXL+mW9rO6w40LqP5VR5izamsbP+1vZ1+DEAoa95ZDrobqDr/k/GQ8dB5M9J7YUpjZ5F+f1/l1Z85TWt0wbNwwIHdeShyHFPYRQvtZ3TERQr3QEqfK7LAI9z8XRBPpFovRM2PI7/BLKUghwT8BldLqTzVzB3iFg3d4p9dtTs9Hp1FxadSYAbDSMcidlxJHIcMdRwjtc46b0XBEhDNVdRromP70+imLeTH5RXY+Po0Q96G51b6wppCzlWf5adRPWwqtFsjaCVOu6VC/KVQwp6wWtaIwOdAdV/3w+hOXOy8ljkDO2EcIrWd7TRyyRhKrZKJgy8fd2l0zP9R2JNy2c9sG1tBe0ORfb7NwmncQ6so7uGHaLx5bhOB4QaUMFZSMSqSwjyCS4oPZvXJ+s7gfFuNwU+oYp+QBbd01oR6hTPCaMOSF3UXjQpRPKx9z5g7bv+0WTu2FCposQoYKSkYlUthHICsWR6FTqzjUuIAap2TaXYS7LPQyUgpSKKsrGwwzuyW9OJ0Yvxg0qlbulMwdMGYyuLdNESBDBSWSFqSwj0CS4oN5NimWUyKIGqFntvGs3UW4+WHzsQorO3N2DpKlnWOymDh2/hgxvjEtheYGOLvXbpijDBWUSFqQwj5C+ekFoUwM8CLbMIGfBhXbXZCL9o3GW+/Nntw9g2Bh1xwvO47JaiLGr5Ww5ySDqcausMtQQYmkBSnsI5ipIZ4kN0Qg8g+Bxdzhc5Wi4qKgi9iTuwersNppYfBIL7adh95mxp65A1BsGR3b0bR4rFPb/qRlqKBkNCOFfQQTF+LFvvpwFFMNFB+3W2dO0BxK60o5ft7+54PBhtQcVm39BmF24WevHm+JbMncAYHTwGg/U+Ps8b40WKz8fuEkdq+cL0VdMmqRwj6CmRrsyWHR8QzU1swOmg3A7pzdA2VWlzSFLdapsrDUBZNbVsej6w7z2f4TcG5fl2kEthwpABhWu00lEmcghX0EMznQnXOqIOpVLpB7wG6dMS5jmOg9kb25ewfYOvu8sPkYteY6VPoCLHW2jVO1Jgtbt3wGVhOM6zyNwOb0fCJ8XZjk7zZQ5kokQxIp7CMYvUbNpABPTmsmdDpjB5s75kDhAWpMNQNonX1yy2pRaUtRFCvW+paQxkm1B0ClgbBZdq8rrzWx91SJPAJPIkEK+4gnLtiLHxrCEflptnBBO8wOmo3JaiK5IHmAretIkJcRRWuLqxcmr+byedoMCLkAdK52r9t2tBCzVbBIumEkEinsI52myBjFUs9Vf3yzQ6ZHgAT/BAxqw5AIe1yxOAq9oRwAa6Owj9XWMUWc7sa/ns9Ydz3xoV6d1pFIRgtS2Ec4JVX1HBKNO1BVp+0et6ZX65kRMGNILKAmxQdzWawOhArM7gR7GXllVrUt300naXptR+AVDZsj8CQSZyOFfYTz4Q9nOSvGUi5cmKq0zfTYmjlBc8iqyCK3KncwzGyDh1sVQW4BZK66ht0r53ORkg4aI4Qk2q2/60QxNcPoCDyJxNlIYR/h5JXXAQqHrOOIa0zhCx1zqDSFPQ4Fd0xedR4Brq1EOnMHhF0EGr3d+pvT83E3aLhomByBJ5E4GynsI5ygVpkeo5Rz6GloU97EOM9xjDWO5fu8jgdgDzR5VXkEugXavqkqhMIjnfrXbUfgFTB/GB2BJ5E4G/kkjHBWLI5Cq7bN2HWKhSjlnN0cKoqicFHQRfyQ98OgphewWC0U1BQQ5BrEhtQcnvjrPwC4faer3dzq+7POc77GJN0wEkkrpLCPcJLig/n95ZM4bLXtQL3ENbvTHCoXBV5EWX0ZR0uPDrSZzRTVFmERFgpKDTy67jCTa1OpEC5srwjssOi7ITWHX723H4A/fX5EHqohkTQihX0U8Ou54yjV+lOt8WJFXHWnOVRmBdk2/wzmLtS8atuhIF8fbqDWZGGOKp0frFOwoG6z6LshNYeVnxyiusF2uEZeeV0H4ZdIRitS2EcBGrWKmCBPjqsmQO6PndbzM/oxwWvCoPrZ86pswl583oUQpYhwVSG7rS0ZHpsWfV/YfIw6c1uXkb1oH4lkNCKFfZQQF+LJ93VhiMIMaOg8dcCsoFmkFKQMWnqBphl7gGsAs1S21L17Wgl706KvPDFJIukcKeyjhKkhnqSYI1GEBfIPd1pvXsg8TFYTe/MGxx2TV52Hu86dhxdNY7b6GCXCnePClgys9aKvPDFJIumcfgm7oig3KIqSriiKVVEU+7tHJEOCwor65jNQX3p/Tae+6AT/BNy17nx37ruBNK+Z/Op8glyDSIoP5nKPs2SoJ6OgdDg44+aLwjpcK09Mkkhs9HfGngYsA3Y4wBaJk9iQmsNLXx+nEG8KhBdh9cc6XWjUqrTMCZ7DjuwdgxL22Lw5qaYU96pMLr7sCl762XQAfrfmx+ZcN7UNFhQFAjwMKMgTkySS1mi6r9I5QogMQKZJHeK0Xmg8ZB3HVCWT2gbbQqM9IZwXOo9NWZtIK05j6pipA2prfnU+8WPjIceWP35XbSSPbjlMrckW/ZJTVsvKTw7hbtAye7wv//7VRQNqn0QyHJA+9lFA6wXFw9ZxjFdycaW204XGS4IvQa2o2X5u+wBZaKPGVENFQ4Vtxp69HxQVT6fom0W9iTqzlaKqepZODRpQ+ySS4UK3wq4oyjeKoqTZ+bq2Nx0pinKHoijJiqIkFxUV9d1iSa9pvaB4SESiUgQxSlanC42eek+mj53Od9kD62fPr84HINA10CbsY6M5Wd55/SWxcrepRGKPboVdCHG5ECLWztfG3nQkhHhDCJEohEgcM2ZM3y2W9JoVi6MwatUApDUuoCZos7pcaLw05FKOnz8+oNkem0IdA138IScZQhI7HXz0GhVeLroBs00iGU5IV8woICk+mOeXxRHkaaAYT/KEL/8TWtrlQuO8UFvu84GctTfN2AMsAurKIXB6m0GpNdfPCBkwuySS4UZ/wx2vUxQlG5gFfKEoymbHmCVxNEnxwex5dAEXT/AjUzeJ0Nqu88FEekYS7hE+oMKeV52HSlExpq7aVuAd0TwoBXsZUQBXnRqNSmHlFZMHzC6JZLjRL2EXQqwXQoQIIfRCCH8hxGJHGSZxDnEhnuytDYPSU1Bb1mXdeSHz2Je3j2pT9YDYll+dj5/RD21lo/vHyxarnhQfzO6V8zn55ysx6jRcPsUfd4N2QGySSIYj0hUzypga7MmPjZkeyTvYZd35YfMxWU3sytk1AJbZhD3QNRDKztkKPNq6in44XUJxVT1Lp8loGImkK6SwjzKmhno1p/AlN7XLutPHTMdb783Ws1sHwLJWm5PKz4JbAGgNbT7/7FAuLjo18yePHRB7JJLhihT2UUaQpwG1qy8l2iDIPdBlXbVKzaWhl7Izeycmi8mpdgkh2s7YvULbfN5gtvJVWj4Lo/0x6joupkokkhaksI8yFEUhLsSTNMZ1O2MHmzum0lTJ/vz9TrWrtK6UBmuDbcZedhY82wr77pPFlNWY5KYkiaQHSGEfhUwN9mRPbahNQKtLuqxbVBgGVh2//Pid5jwtziC/pjHU0egPFTkdZuyfHczFw6Dhkkl+TulfIhlJSGEfhcSFeDVneiSv81n7hgXkacoAABGSSURBVNQcnthwHFPVJNRuR8gpq3baKUX5VY3CrmjB0tBmxl5nsrDlSAFLYgPQa6QbRiLpDinso5CpIZ6k9WAB9YXNx6g1WTBXxqDSVqAy5DjtlKKmGXug2Wwr8Apv/mz7sUKq6s0yGkYi6SFS2Ech/h4GjO7eFOpCuzwqrylJmLkqCiFUaNzT25Q7kryqPPRqPd7VpbaCVq6Yzw7m4euqY9Y4X4f3K5GMRKSwj1KmhnhyyBrZ5Yy9OU+L1QVLzTi07mmA1SmnFOXX5BPgGoBS3hjD3uiKqa438+3RAq6MC0Sjln+uEklPkE/KKCUu2Iu9dWG2hcrKArt1WudpMZUlotIX4+r/rVNOKcqrziPAJQDKz4HRG/RuAHyTUUCdySrdMBJJL5DCPkqZGurJIUvjAmon8eyt87RYKqahrZmFyudbDN6dn5naV/Kr8xtDHc+1WTj97GAeAR4GEsO9Hd6nRDJS6dcJSpLhS1ywJ4dFJFZFg+rs9xB1hd16SfHBzVkgGyyLuH3z7Tyx+wkiPCKY7OOYRFwmq4mimqJGYd8CfhMBKK8x8d3xQm6dFYFKJU/pkkh6ipyxj1L83PT4enmRpY+Cs3t7dI1OreOly17CXefOA1sfoLSu1CG2FNUUIRDklxioLc7irTQLc1ZtZdVXGZgsQrphJJJeIoV9FBMX7Mn3lijb+aINNT26xs/oxyuXvUJJXQkPbn8Qk7X/qQaaDtjYvL8II/XkCD9yympZk3wOH1cdU0M8+92HRDKakMI+iokL8WRL9XiwmmwnFvWQGL8Ynpz1JMkFyazet7rfdjQdsOFTZxskcoRtd6lVQL3JIg9Ll0h6iRT2UczUEE9SrFEIFDizp1fXLh2/lNtibuOjYx+x9vjaftnRNGMPM9cDkC1ajk6sbrDYvUYikXSOFPZRzLnSGipx4Yg1jOQdn/c6VcBvE37L7KDZPPfDc6QWdp9QrDPyq/PB6kIY5wHIFi35YII8DZ1dJpFIOkEK+yhlQ2oOf/o8A4C91mjiLEd5Zt3+Xom7WqVm9dzVBLkG8bttv2t2qfSW3KpcAlwCCFeXUiUMlOMKgEqBh5fII/Akkt4ihX2U0pQHBmCrNR69YiLBcqjXeWA89Z68Mv8V6ix13PrFb5i9ahORK7/oVSbI7KpsYseOY2FQPYWqMYDNp/7TxNAuD9yWSCT2kcI+Smmd72W/dTKVwsh81YE+5YEZ7zWepOAV5NScpNTl3wis5JTV9igTpFVYyanMIdQ9lEBRxLgJU3h1eQIAN18U3uW1EonEPlLYRymt872Y0LDDGsd89Y999ml/ttebhqKFaD1/xBC0BhRTjzJBFtYU0mBtIMQ9xHYknlcYGXkVqFUKE8a69ckWiWS0I4V9lNI6DwzANms8Acp5nr3I2qf2cstqaSi5jPrCJWg9D2IMewvU1d2+AZyrtCX9CtH7QF05eIZyNL+C8WNcMWhl7nWJpC9IYR+ltM4DA7DdMh2BwmWqvkW32N4AFBpKLqU2+ybUhmxcw/9BgG9Vl9dlV2YDEGoRtgLvcDLyKpkc4NEnOyQSiRT2UU1SfDC7V85n3W9mU4wn573j4PimPrXV+g3AXDmN2rO/QtHUYA18pctQyHOV51AragKrbOkJKt3HkVNWy5TAzoV9Q2oOc1Zt7fUirUQyWpDCLmF6iBdj3fXsVGZATsr/b+/eg6uq7gWOf3/JCXlAxoQEQnKAQqyCRKXRtOKj9UFRa1uMpbb9p5bRO5SxdUqnpRcvM/dy/aPaMnWmra3VsU69nV5lqkixPnj4qJdaQORhiiE8ApKngbQJQUg4nPO7f5x90pNwzsnjvHZOfp+ZM9k5e2XvXxabX/ZZa+214HTHiI8x+BMAvbP5+Oj99Pblcu9r9/Ha0ch/MJp6miifWI6n8xBIFvV9wYeT5pYXRiy/YU8LD66vo6XrLArD7qQ1ZjyxxG7IyhIWzSvjmRPOPOuHtozqOLXV3v47d78q6iulu3E5vjPTWfn2Sp6qewpVHfAzzT3NzCicAScaoHgW9SfOATAvyh17+DDNkGQt12fMWGWJ3QBwW9U0dvtm0Js/ddTNMRAh8foncvrDe/GcvYqf7/45a/62ZsDEYU2nm4KJ/eRBKJ3DgfZTFBfkMLUwN+Lxo3XGJmO5PmPGKkvsBoAFlSUU5uWwJ28BHH4d+npGdZyICVZz6Dp2N8uuXMb6Q+v5ztbv0HOuh1PnTtHd1830iRXQeQSmXEp9Ww9zphVGnfgr2rJ8yViuz5ixyhK7AWCCJ4uFc6fyy85Pg+9jHnxozag6JqMn3gIeqH6Ah657iHfb3+WeV+9h9bbVAJxu80PAxw/f6mVfUxc5MdY2HTxMEyA/Jzspy/UZM1ZZYjf9igsm8M65ShoC0/l69puj6pgcKvHedcldPL7ocdo/bmdbyza+UL6M+m3BOWYOB7wosL2xM+o5wztpBfAW5fPwV66wqQeMCWNL45l+r+1vB4Tn/DfzXzm/Z64c54BvJms3NQw7cYbKrd3UQGvXWSqK8ll525wBP7+gfAEvLH6BXn8v33z8GIsD6yAbjmhwpSSfX2OeM3y5PmPMhSyxm37t3b0AvOi/gR951rHcs5EVvu+OuGNyOIm3YlIwibd21fPJnGbatZgeCvr3W2eoMaNnTTGmX6h9vItCnvbfTm32O8yTYxHbzRP1kFBFUT6fkiPUBWZHjMUYM3KW2E2/lbfNIc8TvCSeOP9lunQi/z7hjxd0TCbyIaH/uLmMi7Pa2BO4pP896ww1Jj6W2E2/2movjyy5ksJcD6eYyO89X+FG2UPt5A8HlEvkQ0JfLA7+MfiwoAqASbke6ww1Jk6W2M0AtdVeXl3xWbIEzsy/FyZNg63/DWFPjCb0IaHmnSDZPPDNrwPwY0vqxsQtrsQuImtF5ICIvC8iL4pIUaICM+kzvbiA2movT+/8iFMLfgBN2+Hgpv79CX1IqGkHTLucA53BTwBzp0WeI8YYM3zx3rFvAS5X1SuBg8CD8Ydk3GDFwkvx+QN8dnMFRwNlHHluJRt2Hwfg5rlTGPxc6OB28Vidq6F9F696iTNHd9KYV8WB9h5ysoXZpRNT8esZk9HiGu6oqpvDvt0OfDW+cIxb7D7+T0SE7nPws6yv8VjWL3liwxPsOv4NXnivhfCpvARYcvW/hjiGOldD7fChztWQB9fXcd7Xx2rP/1JAL786Ukp91wkunjIp5lOnxpjhSeQ49nuBdQk8nkmjtZsa8AeC6fvlwDUsD7zEanmavbv/j3laQnN2Ka1aSouW0qolvF0/AWqv6P/ZgO8ss6STCunEKyfx6kk8f36CMj3Jy9KBN7eTXPHxu/O3suH8p6G9hy/PL0/nr2xMxhgysYvIVmBahF2rVfVPTpnVwHngDzGOswxYBjBz5sxRBWtSJ7wjVMniB77lfM+znulygqrso5TKqQHl/b0Cj3qhoJgNZ48zJa97wP6ACh3ni2jVEvbrLDYHangnUMXbgfnOSZRLrX3dmIQYMrGr6udj7ReRpcCXgIU6eLLtgcd5EngSoKamJmo54w4VRfm0hCX3Bp3J/b4V/d/n0dd/N14hnVyW18XS2R4408nfTpRxsLeYVi2hlVKatZSPdDJTi4KJuyXK6BnrODUmMeJqihGR24EfATeq6pnEhGTcYOVtcwa0kw/WSy6NWkGjVpCfk821X7oCnDb2wJ4WfjvoZ8M7V6Mdd46tc2pMQsTbU/UYUAhsEZG9IvKbBMRkXCA0i2J2lHnRs0Wizq4YawbG2movS672XjCqBmBnY2dSfhdjxhuJ0XqSNDU1Nbpr166Un9eM3OxVLxPpChHg6CNfHNUxr3/kjYjNMd6ifP666pZRHdOY8UBE3lPVmqHK2dgyE1O0h45yc7Jo+sfoWt9seTtjkssSu4kp0sIZniwhEICFj/6FRzc3cPZc5Hb4aGx5O2OSy+ZjNzFFWzjjmsrJPPzKAX7xxmGef6+ZW6umsXl/O23dvREX1wgXqWM215NlMzoakyDWxm7isqOxk++v20urs0hHSH5OdsxZGjfsaWHtpob+tvaf3T2fJVdPT3q8xoxl1sZuUuKaypKI75/1+fnxK/VEu3Gorfby11W3cG1lCfNnFFlSNyaBLLGbuLUNulsP6ejp44afvMmajfvZdugkPn9gwH5VZX9rN5dX2Ph1YxLJ2thN3AY/pRpSlJ/DZeWFPLvzOL975xiFeR5umjOVRfPKuPHSKbzV0MGp3vNUVVyUhqiNyVyW2E3cInWG5udks2ZxFbXVXs6e87Pt8Em2fNDO6/UdvLSvlewswR9Q5k+/iDuuiDQVkTFmtCyxm7hFGzkTej9/QjaL5pWxaF4Z/oCyt+mfbK3vYHLBBJZeP8um6jUmwWxUjDHGjBE2KsYYY8YpS+zGGJNhLLEbY0yGscRujDEZxhK7McZkGEvsxhiTYSyxG2NMhrHEbowxGSYtDyiJyAngw5SfGEqBk2k471DcGhe4NzaLa2TcGhe4NzY3xvUJVZ0yVKG0JPZ0EZFdw3lqK9XcGhe4NzaLa2TcGhe4Nza3xjUc1hRjjDEZxhK7McZkmPGW2J9MdwBRuDUucG9sFtfIuDUucG9sbo1rSOOqjd0YY8aD8XbHbowxGS+jE7uI3C0i+0UkICJRe7dF5JiI1InIXhFJ+kTxI4jrdhFpEJHDIrIq2XE555wsIltE5JDztThKOb9TX3tFZGMS44lZByKSKyLrnP07RGRWsmIZYVxLReREWB39W4rielpEOkTk71H2i4j8won7fRG5yiVx3SQi3WH19Z8pimuGiLwpIh84/ye/F6FMWuosLqqasS/gMmAO8BZQE6PcMaDUTXEB2cARoBKYAOwD5qUgtp8Cq5ztVcBPopQ7nYJYhqwD4H7gN872N4B1LolrKfBYqq6psPN+DrgK+HuU/XcArwICLAB2uCSum4A/p6G+yoGrnO1C4GCEf8u01Fk8r4y+Y1fVelVtSHccgw0zrs8Ah1W1UVXPAc8BdyY/Ou4EnnG2nwFqU3DOaIZTB+HxPg8sFBFxQVxpoapvA/+IUeRO4H80aDtQJCLlLogrLVS1TVV3O9s9QD3gHVQsLXUWj4xO7COgwGYReU9ElqU7GIcXaAr7vpkLL7hkKFPVNme7HSiLUi5PRHaJyHYRSVbyH04d9JdR1fNAN1CSpHhGEhfAEuej+/MiMiPJMQ1Xuq6r4bhWRPaJyKsiUpXqkzvNeNXAjkG73FxnEY35xaxFZCsQaZn71ar6p2Ee5gZVbRGRqcAWETng3GGkO66kiBVb+DeqqiISbdjUJ5w6qwTeEJE6VT2S6FjHsJeAZ1W1T0S+TfBTxS1pjsnNdhO8pk6LyB3ABuCSVJ1cRCYBLwArVPVUqs6bLGM+savq5xNwjBbna4eIvEjwo3ZciT0BcbUA4Xd505334hYrNhH5SETKVbXN+bjZEeUYoTprFJG3CN7pJDqxD6cOQmWaRcQDXAR0JjiOEcelquExPEWw78INknZdxSM8marqKyLyaxEpVdWkz9UiIjkEk/ofVHV9hCKurLNYxn1TjIhMFJHC0DZwKxCx5z7F3gUuEZHZIjKBYMdg0kafhNkIfMvZ/hZwwacLESkWkVxnuxS4HvggCbEMpw7C4/0q8IY6PV5JNGRcg9pgFxNsu3WDjcA9zkiPBUB3WNNb2ojItFDfiIh8hmBuSvYfaJxz/haoV9VHoxRzZZ3FlO7e22S+gLsItof1AR8Bm5z3K4BXnO1KgqMa9gH7CTaVpD0u/Vdv/EGCd8JJj8s5ZwnwOnAI2ApMdt6vAZ5ytq8D6pw6qwPuS2I8F9QB8BCw2NnOA/4IHAZ2ApUpqqeh4nrYuZ72AW8Cc1MU17NAG+BzrrH7gOXAcme/AL9y4q4jxmixFMf13bD62g5cl6K4biDYx/Y+sNd53eGGOovnZU+eGmNMhhn3TTHGGJNpLLEbY0yGscRujDEZxhK7McZkGEvsxhiTYSyxG2NMhrHEbowxGcYSuzHGZJj/B3LW/ZX17+WbAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXIAAAD4CAYAAADxeG0DAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8vihELAAAACXBIWXMAAAsTAAALEwEAmpwYAABV60lEQVR4nO2deXxU1fn/32cmM5M9k32HLAQSEggDARQUQcRQ3GltXb4q1Zaq1f78aqu0ta217bfUWrtoF7VabYst1YKiohEUcGXNwpawhCUEQhaSyZ7Mdn9/TGbIvk4yM8l5v17zmsm9557z3Ju5n3vmOc95jlAUBYlEIpF4Lyp3GyCRSCSSkSGFXCKRSLwcKeQSiUTi5Ughl0gkEi9HCrlEIpF4OT7uaDQiIkJJSkpyR9MSiUTitezbt69GUZTI7tvdIuRJSUns3bvXHU1LJBKJ1yKEON3bdulakUgkEi9HCrlEIpF4OVLIJRKJxMtxi4+8N8xmM+Xl5bS1tbnbFEk3fH19SUhIQKPRuNsUiUTSCx4j5OXl5QQFBZGUlIQQwt3mSDpQFIULFy5QXl5OcnKyu82RSCS94DGulba2NsLDw6WIexhCCMLDw+UvJYnEgxmxkAshEoUQ24QQxUKIQ0KI/zeCukZqjmQUkP8XicSzcYVrxQI8oihKvhAiCNgnhNiiKMphF9QtkXgtxjYjO8p3EKIL4YqEK+QDUTJqjLhHrihKhaIo+R2fG4FiIH6k9bqDu+++m6ioKLKysrpsr62tZdmyZaSlpbFs2TLq6uoAKCwsZPPmzc5yTzzxBE8//fSA7dTX13PnnXeSmppKamoqt99+u7NOV9Ldvk2bNrF27doh2SoZGsY2IxuObeDeLfey5D9LePyzx3nwowf55pZvUtVS5W7zJOMUl/rIhRBJgAHY1cu+1UKIvUKIvdXV1a5s1mWsWrWK999/v8f2tWvXsnTpUo4dO8bSpUudYthdKAfLPffcQ0pKCqWlpZSWljJlyhRWrVo1UvN70N2+66+/njVr1ri8nYmOQ7y/teVbLPnPEn7y+U843XCaOzPv5N/X/Jsfzv8hB6oPcOd7d1LWUOZucyXjEOGqFYKEEIHADuAXiqJs6K9sTk6O0n2KfnFxMRkZGS6xZSScOnWKa6+9loMHDzq3TZs2je3btxMbG0tFRQWLFy/mwIEDTJkyhdbWVuLj4/n+979PcXExZWVlnDhxgrKyMh566CG+853vdKn/+PHjLFu2jOPHj6NWqwGwWq2kpqaSl5dHRUUFTz/9NO+88w4ADzzwADk5OaxatYonn3ySt99+m9bWVhYsWMDzzz+PEILFixczf/58tm3bhtFo5KWXXmL+/Pk97GttbWXv3r0899xzPPHEEwQGBvLd736X0tJSvv3tb1NdXY2/vz8vvvgi6enpXez2lP/PWFNQUEBeXh5GoxG9Xk9ubi4GgwFjm5EPyz7kg9MfsKtiF1bFSkJgArlJuVyddDUZYRldXCmHag5x39b7EELwUOJDHPn4SI86JZKBEELsUxQlp/t2l4QfCiE0wH+BdQOJ+GD46duHOHyuYeSGdWJ6XDA/uS5zWMdWVlYSGxsLQGxsLFVVVWi1Wp588kmnMILdXVFSUsK2bdtobGxk2rRp3HfffV3irw8fPsysWbOcIg6gVqsxGAwUFxej1+v7tOOBBx7gxz/+MQB33HEH77zzDtdddx0AFouF3bt3s3nzZn7605+ydevWHva98sorvda7evVq/vKXv5CWlsauXbu4//77+eijj4Z1rcYTBQUFbNiwAbPZDEBVYxXPbH0GywkLxc3FWBUriUGJrMpc1at4dyYzIpNXv/Qqq95dxZMlT5LTnkM44RiNRjZssN8yUswlw2XEQi7s39yXgGJFUZ4ZuUnezTXXXINOp0On0xEVFUVlZSUJCQnO/Yqi9HqzD+aX0bZt23jqqadoaWmhtraWzMxMp5CvXLkSgDlz5nDq1KlB29vU1MTnn3/OzTff7NzW3t4+6OPHM3l5eZjNZtrUbRyJOsLZkLMoQiHQGMiqWavITcolPSx90IOYySHJLCpfxFb9VnZP2s3ss7OJborGbDaTl5cnhVwybFzRI18I3AEcEEIUdmz7gaIoQ3cedzDcnvNoER0dTUVFhdO1EhUV1WdZnU7n/KxWq7FYLF32Z2ZmUlBQgM1mQ6WyD1HYbDb279/P7NmzKSsrw2azOcs74rfb2tq4//772bt3L4mJiTzxxBNdYrsd7fbWZn/YbDb0ej2FhYWDPmaiYDQaMalNfJLyCWa1mcl1k0kwJhDcHsxD9zw0rDrNtWYurb+UPYl72Jewj5kVM0moT8BoNLrUdsnEwhVRK58qiiIURZmpKMqsjtewRdwTuf7663n11VcBePXVV7nhhhsACAoKorGxcUh1TZkyBYPBwM9//nPntp///OcsXbqUSZMmMXnyZA4fPkx7ezv19fV8+OGHwEVBj4iIoKmpiTfeeGPAtgZjX3BwMMnJybz++uuA/ZdBUVHRkM5pvKLX6zkRdgKT2sSCUwvIrMwkpD2EUH3oiOrUWrXMPz2f8OZwiuKKKAsp69elJpEMhMfM7PQEbr31Vi699FKOHDlCQkICL730EgBr1qxhy5YtpKWlsWXLFmfkx5IlS5w+7/Xr1w+6nZdffpljx44xZcoUIiMj2blzJ3/5y18ASExM5Ktf/SozZ87k9ttvd/7c1uv1fPOb32TGjBnceOONzJ07d8B2BmvfunXreOmll8jOziYzM5O33npr0OcynlmwdAGnw04T2xCLvk0PgEajITc3d9h15ubmotFo8FF8yCnPIbIpkoOxBzlmPsbatWspKChwkfWSiYTLolaGgidHrYw1R44cYcWKFTz77LOsWLHC3eb0yUT8//wh/w/89cBfWVG9AmpwWYRJ50gYs8rMF5O/oFXTyuUnLyeEEFauXCn95ZJeGdWoFcnwmTZtGqWlpe42Q9KN+vZ6Xit5jWWTl7H2rrUurdtgMGAwGFi7di1Go5Gc8hw+Sf6E/Ph8FpxaIAc+JUNGulYkkl74++G/02xu5lvZ3xq1NhwDnP5mf7Irsqn3q6ckqkQOfEqGjBRyiaQb9e31vFZs741PDZ06au10HuCMaYwhqTaJk+EnaYwe2gC6RCKFXCLpxj+L/0mTuYlvzRy93jhcHPh0kF6Vjr5Nz97IvZxtOjuqbUvGF1LIJZJONJgaWHd4HUsnLWVa2LRRbctgMLBy5Upnzzw8JJzHsx9HrVLzvR3fw2w1j2r7kvGDHOyUSDqx7vA6Gs2N3Jt975i05xj47Iw6Vs3/bv9ffpv/Wx6d++iY2CHxbmSPvBNJSUnMmDGDWbNmkZNzMcJHprGdGDSaGvlH8T9YkriE9LD0gQ8YJa6afBW3pd/GPw7/g4/KZM4bycBIIe/Gtm3bKCwspHOcu0xjOzFYV7yORtPY9cb745GcR5gePp3HP3tc+sslAyKFfBC89dZb3HXXXQDcddddvPnmm5hMJn784x+zfv36LjMnDx8+zOLFi0lJSeEPf/hDj7qOHz/Ovn37+NGPfuTc9uMf/5iioiKOHDnC9u3bufbaa537HnjgAWfWwieffJK5c+eSlZXF6tWrnYm2Fi9ezGOPPca8efOYOnUqn3zySa/2vfLKKzzwwAM9bCotLWX58uXMmTOHyy+/nJKSEpddO2+hydTEPw7/g8UJi5kePt3d5qBVa3n6iqdRFIVHdzwq/eWSfvFMH/l7a+D8AdfWGTMDvtT/xA4hBFdffTVCCL71rW+xevVqQKaxnQi8VvIaDaYG7p3l/t64g8SgRJ5c+CQPb3+Y3+X/ju/N/Z67TZJ4KJ4p5G7is88+Iy4ujqqqKpYtW0Z6ejqLFi0aUh0yja330Wxu5u+H/86ihEVkhntW5s1lk5dxa/qt/P3w35kTPYcrJ13pbpMkHohnCvkAPefRIi4uDoCoqChuuukmdu/ezaJFi2Qa23HOv0r+RX17Pfdl3+duU3rluznfpbCqkMc/e5w3wt4gLjDO3SZJPAzpI++gubnZmfK1ubmZDz74wLkIs0xjO36pb6/n5YMvsyhhEVkRWQMfgD3p1dq1a1mzZs2YZCzUqrX85orfoCiKjC+X9IoU8g4qKyu57LLLyM7OZt68eVxzzTUsX74ckGlsxzMvHXiJJlMT3zF8Z+DCXFz+zZEPxbFU22iLeWJwIj9d8FP21+zn9/m/H9W2JN6HTGPrZmQaW/dxvvk812y4huXJy/nFZb8Y1DGOjIXd0ev1YxLa+Yudv+DfR/7NH5b8gSWTlox6exLPQqax9VBkGlv38cfCP6Kg8O1Z3x70MX1lJhyrjIXfnftdiqqLePyzx3k97HXpL5cA0rUimaAcqzvGptJN3JZ+25DEsK/w0LFaqk2n1vGbK36DTbHxvY+/h9km/eUSKeSSCcof8v9AgE8A35jxjSEd1z1jIYx8+behkhicyBMLnmB/9X7+kN9z0plk4iGFXDLh2Fe5j+3l27l7xt3offVDOrZ7xkK9Xu+Wpdlyk3L52rSv8cqhV9h+ZvuYti3xPKSPXDJhKCgo4P2899kcshk/nR9ZpsGFGwKgKKDYQKXuNWNh53U4XbW2Z38UFBQgtguCQ4N5ZOsjrJ2+lmXzl41aexLPRgq5ZELgCBs8qz2L0d/IjIoZvPvmu+hUuv4F12aDDx6Hw29B03mImAbRmRCTZX+PnkHBsbNs2LgRs9nur3aEJJ4+fZqSkhKXi7vjXMxmM7ObZ/Np8qf8vODn6DV65s4eOCxVMv6QrpVO/P73vycrK4vMzEx+97vfObfLNLbeT15eHmazmZNhJ9GZdSQYEzCbzeTl5fV/4IltsPOPEJUBl9wPIfFw+jPY8mP455fhN1OZuuka7mQDi9X70GOfgGU2m9m5c+eoxJs7zgUgwBzAjIoZ1PrV8tQXT424bol3IoW8g4MHD/Liiy+ye/duioqKeOeddzh27Bgg09iOB4xGI43aRmoCa5hcNxlVx1d/wLDB/FfBLwxuWQdX/wxufx0ePgyPnoS73oHlv+KwZRL+oo3lmt18T7eOZT67UWHtUdWgHhyDPJfOxDXGkVSbRElgCa8ffX3E9Uu8DynkHRQXF3PJJZfg7++Pj48PV1xxBRs3bgRkGtvxgF6v51TYKVQ2FZOMk7ps75OmaijZDNm3go+u6z7/MEi+HC65lw8Db+JZ0838qv12Cm1pLPXZx33ajUSInr+yXBFv3pvNGZUZxLXF8Yudv+DD0x+OuA2Jd+GRPvJf7f4VJbWuFZP0sHQem/dYn/uzsrL44Q9/yIULF/Dz82Pz5s3OVYJkGlvvZ+nVS/lP4X+IaYxBZ7WL8oBhg0Wvgc0Mc+7qt+7c3Fw2bNhAnTmY181LKbYmcZPmY76jfYPNlkvZac0E7BkvXRFv7mjP4V4B0Gl0/GTOT/hT1Z94ZMcj/GrRr8hNGruQSIl78UghdwcZGRk89thjLFu2jMDAQLKzs/HxGfrlkWlsPZQ4MB8wk2pLBRh48FFRYN+rMOlSiOx/EWZHHY6olfLgOXyceg2pB5/hRs0nJKkqWG++Ch+N1iXx5t3b63wu2eZs7t96P499/BhWm5UVKZ6b9kHiOjxSyPvrOY8m99xzD/fccw8AP/jBD5wCLNPYej/bzmxDo9Lw9Lefxl/jP/ABpz6F2lJYNLjFHHoNSUydycebf8wiPqFeF0/wNT91WUhib+0BBGgC+PNVf+bbH36b73/6fWpaa7hj+h29dh4k4wfpI+9EVVUVAGVlZWzYsIFbb70VkGlsvR1FUdhWto35sfMHJ+JgH+TUhcD0G4bdrmH2bBb98G3I+jJXWD7GENIw7LqGgr/Gnz8u/SOLExbz672/5pEdj9BkahqTtiXuQQp5J7785S8zffp0rrvuOv74xz8SGhoKyDS23k6psZTypnKWJA4yW2BLLRzeBDO/CtpBCn9fCAHXPwvhqfDWt6GtfmT1DRJ/jT+/W/I7vpvzXT4q+4hb3r2Fo3VHx6RtiRtQFGXMX3PmzFG6c/jw4R7bJgIlJSVKSkqK8u6777rblH7x5v/Pi/tfVLJeyVLON53vt1x+fr7yy1/+Utn0gy8pyk+CleJt/3GdEWW7FeUJvaJsvM91dQ6Svef3KkvWL1Fy/pGjvHnszTFvX+I6gL1KL5rqkT7yiYRMYzv6bDuzjczwTKIDovssc3G2pIm52sOU2aJY9+F+VoZMcY1fO3EuXPYwfPI0pF9jf3VqezSn98+JnsN/rvsPj338GI9/9jj7Kvfx/fnfx8/Hz2VtSNyLdK1IxjU1rTUcqD7A4sTF/ZZzzJacJCqJUdWxx5rhsgk8Tq54DGJmwKbv2GPUGbsVhyL8Inhh2QusnrmaN4+/ye2bb+dk/UmXtiFxHx4l5IobViuSDIw3/18+Lv8YBWVA/7hDSOepD9OuaCiypnXZ7hJ8tHDTC9DeAO88BIrSZbq9A5c/QDpQq9Q8aHiQP1/1Z2paarjlnVt47+R7Lm9HMvZ4jJD7+vpy4cIFrxaN8YiiKFy4cAFfX193mzIstp3ZRlxAHFNDp/ZbTq/Xo6OdmepSCq1TMKFxbncp0dPhyseh5B3Yv94tKw4tjF/If677D9PCpvHox4/y850/p906DucOTCA8xkeekJBAeXk51dXV7jZF0g1fX98uk5q8hVZLKzvP7WRl2soB46hzc3M5s/EJtMLCbut0YBQXjLj0ATjyHmz+Hokhd3Cm3tajyGivOBQTEMNLuS/xbMGz/O3g39hVtouZp2divWAdkzS8EtfiMUKu0WhITk52txmSccTOcztps7YN6B8HMMyaxbTt5VQ2RHNWiRxdMVOp4cY/w58XcmfIF/y6ZSEm88VJXGO14pBGpeHhOQ+jb9LzXOlzlIeXM9M0E4yMahpeietxiZALIV4GrgWqFEUZQrZ+iWT02F6+nSBNEDkxPRYd78m5Avzrj+O/4mnWzvvm6BsXlgy5vyDonYf41ox5/ONEqNsEs+qLKi5ruoyChALyE/JJqk0iozKDnTt3Oss4BmEBKeYeiKt65K8AzwF/d1F9EsmIsCk2tp/ZzmXxl6FRaQYsT/6r4ONnnwQ0VsxZBaUfEV/8Amv+ZwOkDnLCkosxGo3448+lpy6lOLqYU2GnMPoZMZQb8LdcnBDlGISVQu55uGSwU1GUj4FaV9QlkbiCAzUHqG2rHZRbhfYmOPAGZK0E35BRt82JEHYXS8Q0eOPrUHdq7NruhMMfr0JFZmUms8tn06Rt4tOUT6kMrOxSdjQHYSXDZ8yiVoQQq4UQe4UQe+WApmS0+eLcFwgEC+MXDlz40AYwNcHs/tPVjgq6QPuiFYoN1v8PmFrG3ITc3NwuqZZjG2O57ORl+Jn92Ju4l+LIYmzYB2RHexBWMjzGTMgVRXlBUZQcRVFyIiMjx6pZyQSlqLqIVH0qIboBetg2G+x6HiIzIHHe2BjXnfBU+PJLcP4gvHmv3aYxxGAwsHLlSqdI6/V6ls5ZyhVnr2BS3SRORJxg5+SdWHwtYzIIKxk6HhO1IpG4Cptio6i6iKsnXz1w4aPvQeVBuOl5u6vDXaQtsy8l98Hj8NGTcNUTY9p8b2lxJ0+eTHBeMIfOHuJg7EE+n/I5K6NWjqldksEhhVwy7jhZf5JGUyOzomb1X1BRYMdTEJoMWV8ZE9v65dIH4EIpfPpbCEuF2Xe41ZzO4n6i/gSPbH+Ee7fey+qZq7kv+z7UKvUANUjGCpe4VoQQ/wK+AKYJIcqFEPe4ol6JZDgUVdvzqc+KnNV/waPvQ0UhXP4wqD2gTyMErPg1pF5pn8J/Yru7LXKSEpLCa9e8xg1TbuD5/c+zestqalpr3G2WpANXRa3cqihKrKIoGkVREhRFeckV9Uokw6GwqhC9Ts/k4Ml9F7JZ4cMn7T3f7FvHzriBUGvg5lcgPA3W3wnVR9xtkRM/Hz9+tvBn/Gzhz9hfvZ+b376Z3RW73W2WBA/KtSKRuIrC6kKyI7P7n5Z/4HWoOmzPe6IeRJz5WOIbArettyfZWnczNHtWz/fGKTfy2jWvEagJ5JtbvsnzRc9jtVndbdaERgq5ZFxR317PyfqT/fvHLe3w0S8gdhZMv3GMLBsioZPh1n9DUyX8+zYwtw18zBiSFprG+mvXszxpOc8VPsdX3v4Kn5R/IpPeuQkp5JJxhcM/nh2Z3XehvX+D+jK46ieg8uBbICHHHk1zZpdbwhIHwl/jz9rL1/KbK35Du7Wd+z+8n2988A3yK/PdbdqEwwNGeCQS11FYVYhaqMkMz+y9QHsjfPxrSF4EKaMzJd6lK/5k3gjGJ2HLjyE4HnJ/4VJbR4oQgquTrmZJ4hJeP/o6z+9/nrvev4uZkTNZOWUluUm5BGoD3W3muEcKuWRcsb96P9PCpuGv6WPR5L0vQ0sNLH1iVOLGLy4ZZ18swiXJphZ8B+rL4YvnICQRLrnXVeYOmoEeThq1htsybuPGKTey8fhG1h9ZzxNfPMHa3Wu5ctKV3DDlBubHzJchi6OEFHLJuMFis7C/Zj83TrmxjwLtsPPPkHwFJMwZFRv6W/Fn2EIuBCxfCw3n4P01EBwH0693gbWDYygPJ3+NP7dn3M5t6bdxoOYAm0o3sfnkZjaf3Ey0fzTXpV7H9anXkxwiU1a7EinkknHDceNxWi2tXeLHO/ckLw8s4xpLBdzwx1GzYdRW/FGpYeWL8PfrYcM3ITAaJs0fWZ2DZDgPJyEEMyNnMjNyJt+b+z22ndnGpuObePngy/z1wF/Jjszm+tTrWZ68nGBt8FicxrjGg0d6JJKhUVhVCOCMWOm+sPFs007OKxEUNISOmg19JZVySbIprT/cut7uK//XLVBzfOR1DoKRPpx0ah3Lk5bzp6v+xNavbOWROY/QbG7mZzt/xpL1S3h0x6N8evZTGcI4AmSPXDJuKKwuJNIvktiAWKBrTzJGXCBWdYE3zZdT8sEHGGbPHhUbcnNzu7ghwMUr/gSEw/+8AX9dBv9cCd/YCoFRrqm7D/R6fa+i3dfDqT9/eqR/JKuyVjHTNJN/Hf8XxapiPrR8yHun3iPKL4prU6/lhtQbSNGnjMq5uHQguh9MVhNN5iaaTE00mhtpMjWx/8h+dhftJqA6gJjAGJe2LYVcMm4oqipiVtQs50SgzuJjUB/Fqqg4YE2leRRzajtuzFEVi7AUuO0/8Mo18NpXYdW7oA1wXf3dGMrDaTD+9IKCAjZu3IjarCaLLDKqMrgQcgHLVAuvHnqVlw++zIyIGSxOXExKSAp6nZ4gbRCB2kCCtEHo1DqsNisWxYLFZsFqs2JVrPbPihWrzYrZZnZ+duw7cuwIOz7dgdlqRglUqLBWcOSDI+TU5RA/Kb7XepxtdPrbarOXabG0dBHqJnMTjSb7Z5PN1PvF1MPchrn4Gn1duuKSFHLJuKCmtYbypnJuSb/Fuc3RkxQozFIf46gtkWb8huzmGGovrrdMgi4nYQ7c/Df7ZKE37oavrRu1fDFDeTgNxp/evYxaURNljEJ/VM8z/+8Z3j3xLptKN/FswbOuP5m4npv2ntkLZwY+1Ef4oFapUQs1apUafx9/grRBBGgC0PvqSQxKtD9sNPaHTqDG/uAJ1ASy6Y1NtNW3obFp0Fl0gGtXXJJCLhkXFFX1nAjk6EkmWk8RIpp513rpkN0coxJO6CqmfQlWPA3vPgybvwvX/nbUUvEO9uE0GH96f2Ui/CK4K/Mu7sq8iyZTE2WNZTSYGuw9X1MjjaZGTDaTU1R9VD6oxcV3tUp9cV+397++8FcEApWiQigCgUAo9r8fe/QxfFQ+vdajFvZXvykfBiCvKg8dukFfr6EihVwyLiiqLkKj0jA9fLpzm0N4VO/8P9otGs4FzWLl8muHJMCjEk7oSubeA/Vn7KlvAyJgyQ8pKCwcEz9wbwzGnz5Yn3ugNrDL/3OkbNNt67PdhKAEl7XTG0MdZxgqMmpFMi4orC5kevh0tGptl+2GrAyyfU6im3Uz3/3+j4YsaKMWTuhKrvwxGP4HPv41xheuZ+uGV532OX5BFBQUjIkp3ZeNg57+9MGUcZdt3tq27JFLvB6z1cyhmkPcmm5PR9vZpz0/6Dw3mRtg5s3Dqnu0e1IuQaWC65+DyAyCP3ich1WfcEiTzOeWGZxWYsb0F8Rg/OljMiA8TNu8tW0p5BKvp7i2GJPNxKyoWT182lPbCmlU+XO8Ppjh3DKjHk7oKoSABQ/w1KZiLvE5yDx1MTN1J2hXNJxVIjnTFAWHpkHcbNBPGtVl7QbjTx+TAWEPane025ZCLvF6HBOBsiOzeelfLzlF1482pqlO84V1Bp99sBXD7Jwh1+3KntSYxDDrE3nfGMSHlhwyVSeZpKokQVXFQp8D8Poqexm/UIjN7njNsr+Hpbh3zVLJiPAaIe/vJhirIH9XMFRbzVYzW3ZvYfPOzZyznsMWYOOWGbdwy2W39HnMRKOwupD4wHgi/SO7uEFmqEvxETYKrGkj8mm7oic1VtEvF39BQKFtKoW2qWg0Gr583XXMivGBcwVQUWR/ffEnsHX80tCFQOzMruIePgVUqkF9Zz3lHvQUO8YarxByx03Qbm5HILrcBIDnhod1o6+b2abYiJkaw+n605xuPM3phtOcajhFWUMZZxvPYsMGYYACapuaX5T+go2VG3lyyZNMC5vm3pNyM4qiUFRVRE6Mvbfd2adtUB+j0hbKOSXC7T7tsYp+6esXxCxHG/GdZrRaTFBdDOcKO8S9EHa/CNZ2+35tIE2BybTWqEmxhHFWRFBttPU6wccT7kFPscMdeIWQO26C4uhiToWewsfmg4/Nh4/2foQWLSJGOLf5WO3vZZ+WcUPgDQRoAgjUBDrfA7X2z/4+/l1Sag7lST6cp76iKGzcspHzmvM0BzTTrL342rR/E7YDFxcN8PPxIyk4ienh0wk5F4K6QU2AKYAgUxBCEZwOPc1x23FufvtmVqat5AHDA0T4RbjmYnsZ55vPU9Va5Ywfd/RIA8y1JKsqeN88D41G63af9lhGv3QX87y8vC7bnfhoL7pYHFjN9nVCO3rtxj3vkCMqWaC1AGBSfKhQwql551NQ7qakwZc38vZgVboGwLkjRNPjQ0VHEa8QcseXPaYpFK1NhUllw6KyOF9mtZkWTYv9b7UFq8qefCf/8/5XKvFV+SLMApVFhcamwSfIB58A+4Pgi4+/IOt8Fn4qP04eOYmpyWQv0/Gg8LHZJw/UGmvZsGEDp0+fpqSkhKrGKlq0LTRpm2j3b6dJ00SDuoEWbQuWaIuzbZVNhb/ZnwBTAFFNUdx57Z1MCp5EUnASEX4RFHbEAvsYe/6LUmpTSDQmIhYKNhzdwJslb5LVnMWDCx5k/pyxyYjnKRRWFwIXE2U5btgL7/4MLHAyYA4rv7Ry2Deyzabw7EfHUatgblIY85LDhjUxZCyjX0bUM1VrICbL/jLcznMfqxDYiBRG4kQNCapq4lTVZFoOwKYHSAd+qlXRjB+tipZWfGlRdLSho71JA1taQRtoTyHgfAX28TlgROunjsXDsnMnTgiBoige4cLxCiF33ARfby9lgfUgNgXMaDDhg0npeEfj/NyGlgahocnHh4jUNPyio2kSappU0CwETSiUXajiSPlpWrDSrlJoV1kxqSy0+bRhUdsfECcqT4AAQjpefaCyqXj3wrtYo63YYi/2rIUi8DP7EWAKIKwljABTgPPlZ/ZDYBeEsJAgvpywxL56TWMVRz9/j/07tpBobWWK2owvJnSY0QkTFtR8aMnBTxeMZaeFRWIRJVElFAUX8WDBg3y94evcu/jeEc1C8yYKqwrx8/FjauhU5zaDwQBH/aFiMvc9tHZE9b+9/xy/3XrU+feC1HB+sCKDrPh+vhC9MJbRL67smTruvSoljColjEKb/TrrQ0IIVWoJajpBrOoCgbTiJ9rxo50w0YivqEEnrLDz2EVXzWBQ63oX+IH+VmuZF1RJY3MrVgQ21FgVFTYE/kEhdveRWgMqjT0lsFoDKp9ufzu2qXsd+O36gFRQKxa0WFCMZ/hkw4v41y5kWlKc/T42NUF7E5gaO947/X3FYxAzY0j/h4EQ7lgsNScnR9m7d++gyxcUFLB+/XpSVeUkiGq0wowWM1osA38WFoYiaVZF5XwwtCs+NAgNRpX9vV7lQ6NKRaNQ06RS06QSNKsELSpBuxAIRU2gxYcYsyDWBNFmhQBhRocZX3FRjHWY0WFCJ+wirRGDS99pVtRohJV1pmWU+s6kpaXFua/Gv4bi6GIafBvIjszm0bmPYi23jruBn+5urU+TPyUmNIa/Xv3Xi4UUBZ6eCqlLYOULw26r3WJl6W92EOyr4V+rL2Fjfjl/+Og4tc0mbpwVxyNXTyMxrI+ViAZh+2j9P9asWdPnvrVrh/Zg6967B/sDaOXKlaxfv77P4xxlDAaD3V1jau70aurj8xD2mZuHdB5DxiHy6g6hV2loaG5FpTj0xTJwHQ6EGnSBoA2yv1/zDCQtHJZZQoh9iqL0CL/yih65wWDg7bffZkvLHCrRI1BQoXR7t/XYbv9s4yvXXo3O1oaf0obW1oZOaeXjre/ijwkdJvxEO76Y7D1fYRdZx2dfxUywzUSkMKGlGV3HA0KHeWAB1th9iu1oaFe09ne0NCgBtBGKVeVH4pTpRCemgi7I/tIG8tK612lXNLShpV2xH2NCgwI8plvHHPURDrRM6dJUREsEl528jDMhZyj3Lef2zbeT0JjA1Kap+OE3LgZ+uotKdUM1p1tPYwjudj61J6C5CiZdMqL2/rmzjPK6Vv5+9wxC/DSsWpjMyjkJ/GV7KS99epLNB86zamES3148hRD/gV0CYxXD7Eo3Tn/hl45t3RFCXBRxsIuhn97+chU2G5hbLgq81QQ2CyWHD7J75+e0NNYTHBjAvBwDU5Ing81if6DYLBdfnf/udZ8ZbFbnviO7vsCCGjM+mPDBrGgw44MZtfM+/fq3HrT/Wugs3D6+ox7a6RVCDnDdddex9/VdXLAFdUi26OO9Z9aBgndO9FLjihHbpMKGP2340U6gaCWUJnSY8VFsaLHgi5kA2vvMg6AP0LPmf3r2nqqDS/r06+Vbp7LYp4AEfzXl9V0fJALBTDGTF1e+yD0v3ENxQDHnUs8xv2w+Ya1hXj/w091lYPQzgoCG4gb4UqeCZTvt75MuHXZb9a1mnv3oGJenRbBoaqRze7CvhkeXp3PHpZP5zQdHefGTE6zfc4YHr5zCHZdORufj/jUpXe3G6esB1Fc7XUR8tFCp7CKpCwSinZvTY2aQfuWto9Lkh4fW9utv1+v1MHnBqLQ9EF4j5AaDgZ9ysWfg5+eHyWTCau0qZorzJVD7aLnmuuuZnpmFxabYX1YbFpvCgYOH2fLhh5gtVmy9PBTSpqYTHhHJ57t2Y7FasTn7913LaX39CAuPpLyilVpbCA34YyQAW4d8q7Gip5lQmtHTRChN6GlGjdLnl6K3G8RBkcjiSvK5KdXEXw749nqzBmgCSDqTRJRPFJ8mf0pZaBlhrWGAh+UIGSLdba/1r0UoAk11t97wmZ3gq4eI4Ydm/mVHKcYWM48tT+91f2yIH0/fnM3dC5NZ+34JP3+3mFc+P8V3r57GtTNj8VG7L43RWE1Fd+eUd3fQ333p7tm+XiPk0LNn0N3nmJ6eTklJScffIf1+qVKXzGOyXtPHCPTVzuMuTfQb1Ch1Z1tsCBrwo47AjlcAp4nkOPaVawQKwbQQrTHx109OkBkXwvS4YEL8NM7zBHptd3Hu1yD/KPFV21l50/PkffBBrzeRXq8HI0Q3RXM+6DxWYUWtqN0eTz0SursMav1qCW4LJiKkW+hl2U5InG/vtQ2DivpWXv70JDfOihtwUHN6XDB/v3senxyr5pebS3hofSFr3yvhtvmTuGVuIlHBvsOyYaSMlRvHnVPex5r+7kt3P8C8YrDTm+htcEilUgGCBpuGOgKoI5B6EUSLLpy6totRLgmhfmTGBZMZF+J8jw7W9YxAyf87bHoQvvEhJPQ+7dxhx1ntWfZM2sPcsrnEm+LH5mfvKNH52tqwkTctj+SGZH6y6CcXz6m5Bn6dCkt/Apc/PKx2Hn2jiDcLzvHhI1cMaTDTZlPYWlzJP3ae5pNjNfioBLmZMdx7RSozEoYW5SKR9IZXD3Z6E3393HRsCzReYIbeSm7uJRgMBqob2zl0rp5D5xo4fK6BQ+fqyTtU6awvPEDL9E7iPitRT+L0G2Hzo1C4rk8hd9ixOW8zBdYCLkRc4MFLHvRaEYeu1/Zk20lsKhsrsld0Paczu+zvw/SPHznfyBv7yrl7YfKQRBxApRJcnRnD1ZkxnKxpZt3O07y+r5z3D53ne7nTWH15CirVxAgLlYwtskfugTS2mSmuaOTQufoOcW/gWFUjZquCSsDWh68g5ZOH4cj78N2joOn/5/uaT9bw+dnP2fG1HeMmvvxvB//GM/ueYdtXt3Wd1frBj2DXX2DNmQGvS2/c/coe9pyq5ePvLSE0QDvwAQPQ0GZmzX/3s/nAea7PjuPXN8/0iAFRiXcie+ReRJCvhnnJ9lmEDtotVgrKjNzywk5e2ZJPxkkVt5rrefOp1Uxe8b/99rRnRMzg3RPvUt1aTZT/6K64PlbkV+UzOXhyz9QEZTshzjAsEd954gIflVTx2PJ0l4g42KNc/njbbP68o5Sn3j9CRX0rL9yR47L6h4q3JpXyRrutNoXyuhZO1DRTWtXkfP/RtdOHPKFsIKSQewk6HzWXpISTotfw3oGzmJVgvqQLYFpbIa8NEB/umPV4tO7ouBBym2KjsKqQxYmLu+4wt9qz+116/5DrVBSFX75XQmyIL19fmOQSOx0IIbh/8RQSQ/155PUiVv75c/62ai5JEQEubWcgvDWp1FjYPZIHhbHFRGl1Myeq7WJ9orqJE9XNnL7Qgsl6cQxM768hJSKAdsvgJgAOBSnkXkZoazknlCha0VFoncrl6kK07fX9xoc7hPxY3TEui79sLM0dFU7Vn8LYbmR21MVMfgUFBRx676/8j83MG7vPkhpRMKSbfPOB8xSdMfLrr8zEVzM6ro/rsuOIDfHlm3/fy01/+ozvXRJMWf72MetlemtSqdG2e6AHhdWmUN3Yzrn6ViqMbZypa3GK9YmaZmqbTc66fFSCyeH+pEQGcmVGFKkRgaREBpASGUjYKP4Kk0LuZYS3nwOiqSDUOTlolvo4nxn7HpgL0YUQ5RfFsbpjY2foKLKvah8As6PtQu64ERfajoEGDjcGUTSIHpujF3bBWE+eai6TQwJYOXt0F+HNSQpj4/0LufUvn/D4R9Vcgg+TGJve8VhmYHQlo2m3oii89d5WqsxaWgiiBZ39Zdax5Y1jqPPqqGxow2LrOpYYEaglJTKQ3MxoUjqJdWKon1vmEEgh9zKSQ3zwq2/nLOFUKWGU2yIwqI9yKGhRv8elhaVxzDg+hLygsoAw3zAmBU0CLvbYkjQVVNpCacEXBuixde6FlRJLg01HTtNB9hdFjXrvNCkigFzVAd4hns/J4ALlzOD0gDaPFK9Yf7QXRmJ3i8nCOWMbFfWtnDO2dvrc5uxht5qndzlGhQ0/2vG3mrgkKZQ4vR+xej/iQnyJ0/sRp/dzzvnwFKSQexnLl+ey7fUCTtgisCIosE7lOs3n3HBp/7MYp+qn8s+Kf2K2mdGoPOtLOFTyq/KZEz3HGYFjNBoRKExWnWe/NdVZrr8em0P8m9GxnySiqSPSWj1mboa2hgssoZYCUjhCAuWEk8kZkoxVo9am16w/2o2+7F667GrO1LZQUd9mF+kOYbZ/tgu2saWrS0YIiAzUEav3Y1p0EEumRXF472eo2urxpw1/2vHFjMD+oFhzy21jfLbDQwq5l2EwGPjquTZ+/kktVeg5GZiDYtpJhrkIuKnP49JC0zDbzJQ1lJGqT+2znKdT2VzJ2aaz3J5xu3ObXq9HV1+KnzBx2hbTZXtfGI1GFGAX9vGDuRxDMHZuBkcvM4dSEqmhkGR2M5ViVRKzd5fx5TkJaFz8E90bp9S3W6wExE0hdu6X2JZfTFWbilZ1IBafQP75RgWKUtGlfIifhtiOnvOcyXpiQ/yI0/sSF2LvSUcH+6L16XpdC+LbvfIB1xmXCLkQYjnwe0AN/FVRlJElgZb0y/9cPY/f7NxC4pwVfOfGGbCuBPb/B678MQVFRb1OIU5fZM8ZcqzumFcLeUFVAUCXgc7c3FzObPwpAKcUexqE7jdi96gEf39/8ltCqULPXI4RiD1n9li5GTr3MqOp52oKqVJHciZkBms2HODZj47z7SVT+MqchB7CM1TcFbrXZrbS3G6hxWSlqd1Ci8lCU7uVlnYLzSb7vmaTxf7ebqXFZH93bDvf0MbZulYuuqdjiNf7kRbhT1xId3eHL7EhfgTohi5p3viA686IhVwIoQb+CCwDyoE9QohNiqIcHmndkt7x1ai5PC2CD4ur+NkNCmLm1+C/9/Dqk9+kuO1ipj7HZC+j0cju93ajmqLiaN1Rlicvd5fpIya/Kh8/H78ua5UaDAYm7/OhqTyAWiW418W5u0cl1IpgikgigRpSOA+MbS+su3iE6vXcknsls2bNYvvRan6/9Rg/2HiA5z46xp0LkrhlbiJ6/6FHPYxW6J7NplDR0MbpmmZOXWjh9AV7uN3p2hbqmk0YW020mW0DVwSoBATofAjU+eCvVROg8yFA60N2gp6bDAmkRgaQHBFAamTgsIR6MHh7zhhXXJV5wHFFUU4ACCH+DdwASCEfRa6aHs0Hhys5dK4BS3sC6YqWTOsBirmy1/I2s40gc5DXR67kV+aTHZmNj6rrVzes6QhMv4q1X/1Vj2O6h6+Z8OFTZRoBwsyyoEpaG3BLL6wv8VgyLYrFUyP5+FgNz+8oZe17Jfxu61FuMsRz14Ik0mOCB93GSEL3zFYbZ+taOeUQ6Q7BPnWhmTO1rV1ipLVqFYlhfkwOD2BGfDB6fy0hfhqCfH3w1/oQ4BBonRp/bVfR1vmoxs2MY3fhCiGPB850+rsc6LFwpBBiNbAaYNKkSS5odmKzZFoUQsBHJVW07NmO2ZrCTHUpb1kux0zvg5n+Lf5eHbnSaGrkaN1R7su+r+uOhnNgLIP59/V6XGe/twLsJo1WtFyl7OcnP/jh6Bk8AoQQXDE1kiumRlJyvoFXPz/FxoKz/Gv3GS5NCWfVwiSuyohGPUDuloFC99rMVs7UtnTpVTuE+6yxFWunsDs/jZrJ4f6kRQVx1fRoJocFkBTuz+SIAGKCfQe0RTJ6uELIe/vv9UjgoijKC8ALYM+14oJ2JzSRQTqyE/R8WFJFhtFIgWoqc31KmK46SZFtaq/HRKmiKGoqotncTIBmbGcVuoKi6iIUFAzR3XqSzoUkel8RqHP42imiKCeCWZwgVe8dOU/SY4L55cqZPJqbzvq9Z/jHF6f51j/2kRDqx52XTuZrOZP6XKFIr9dTbWygCT+a8KUJPxrxpc0niAW//JCKhjY6p1sK8vUhKTyAmQkhXJ8dx+Rwf5IiApgc5k9kUC+ZOCUegSuEvBxI7PR3AnDOBfVKBmBpehTPbD1KdnAEJxsU6pRAZquP9irkGo2GK2dcSdGpIo7VHXOuOu8tFBQU8NxnzyECBVv/vhXd1bqLroGynaAJgJiZvR7rGFhsNtsoJJlwGsjyqSI3d+UYnsHICQ3Qcu8VqXzjsmS2Flfyt89O8X+bS/jtlmPcNDueFVmxRARpOVndzOGKBoorGig0zaKGrlPCdZhJCvEnc1I4k8L9SQoPsAt2eAB6f41bxdobc6p4Aq4Q8j1AmhAiGTgL3AJ4R/Cll3NlRhS/2XKUkPRLMRa8T4F1KovVBQTRTCMBPRLfR6VF8dtTv+WY0buE3DFgVxFbQXBbME11TV0H7Mq+gIQ5oO796+wQgp+8WUR7u4ZrAsv48jXem5fdR61ieVYsy7NiOXzO7nb5775yXttV5iyjEpAaGciCtGiCbI1UlR5EtFwgPkTH9cuXeeS5e2suGE9gxEKuKIpFCPEAkIc9/PBlRVEOjdgyyYBMjw0mJtiX4y2+rF65kj3vtXGlKZ9LAs8Sds2Penz5FUUhQBPA0dqjbrJ4eOTl5dFmacPoZ2Ry3WSg04Dd9ClQeRAWfa/fOlLSszhmq2Tl7Bie+eq1Y2H2mDA9LphffWUm31+RzuGKBmqaTCSF+zM1Oqhbzpj+Z/56At6aC8YTcEksj6Iom4HNrqhLMniEEFyZEcVbBWf5/S0dy9O9sJeltiro5YsvhGCKforXDXgajUYa/BqwqWzOtUcd2ynfA4qtT/+4g4355bSarXx9QfIoW+se9P5aFqRGDFzQg/HWXDCegPtWiJW4hKXpUTSbrOw+WWvfkH0LnD8Alb3/KJoaOpVjdcdwx4Iiw0Wv11PrZz+/0JbQLtsp2wVCBQlz+zxeURTW7SojOyFELrnmwfQ1GcvTc8F4AlLIvZwFqRHofFR8WNKxPFzWl0HlA0X/7rV8WmgaDaYGqlpGL6eHq8nNzcUYaCSgPQCdVQd0mrxzZhdEZ4IuqM/j95yq41hVE7fPnzxWJkuGQW5uLhpN1+gbb5sq7y6kkHs5flo1C6fYZ3kqigIBETBlGRx4HWw9E9in6dMA+yIT3kL2rGwagxuJsdrzqOj1evsi0tkzoXwvJMzr9/h1u04T5OvDtdmxY2GuZJgYDAZWrlzp7IE7/8/SPz4gMmnWOODK9Cg+KqmitLqZKVGBkP01OPoenNwBqV1neqaF2oX8mPEYlydc7g5zh8wJ4wmarc2sWraKG6fceHFH5SEwNUJij/lnTi40tfPegfPcNn8S/lr5dfd0vH2qvLuQPfJxwJXp9uXbPnK4V6Z+CXQhULS+R9kQXQjR/tFeNVU/vyof6JooC7C7VQAS+/aPv7GvHJPVxm3z5WxiyfhFCvk4IE7vR0ZsMB8Wd/i9Nb6QeSMUb4L2ph7l00LTvErIC6oKCPcNJzEoseuOM7shIBJCe49EsdkUXttdxrzkMKZG9+1Dl0i8Hflbc5ywND2KP+8opb7FbJ+unX0L5L8KJe/YP3ciLTSNL859wf+t/T8ajA0eP4MuvzKf2dGze844PLPb7h/vYybiZ6U1nL7QwsPLek9Z4KnI2Y2SoSJ75OOEKzOisNoUdhyrtm9IvAT0k3uNXtHWa7EqVs62nAUuzqArKCgYS5MHxfnm85xrPtfTrdJcA7WlkNj3QOe6nWWEBWhZnhXTZxlPwzG70RE77cn/G4nnIIV8nJCdoCdYp+LZNz5izZo1rH3qKSqiroAT2+3ZATtxJt+erLLRt9G5zTGDztM4UHMAgJmR3fKolO+xv/ch5JUNbWwpruTmnAR0Pt6RHAv6n90okfSFFPJxwv6iQiJMlZw2B2LD3pNbX6wAChS/06WsUqMgFEGDrqHLdk+cQXeg5gA+Kh/Sw9K77jizyx4vH9e7y+HtonNYbQq3zvWuQU45u1EyHKSQjxPy8vKIUWowoeEC9oUHzpsDqSfYnlSqE2H6MALaA2jUNXbZ7okz6A7VHCI9NB2tutvqOGf2QGw2aPx6Pe6z4zWkRAaQFOFd6Xrl7EbJcJBCPk4wGo3EUIfAxjku5iM5aY3CVPoxnZNO5+bmEmIO6SLknjiDzmqzcujCITIjMrvtMMPZfX1OBDJbbew+WcuC1PAxsNK1yNmNkuEghXycoNfr0WIlkoYuQn7KFou2rYZDn73n3GYwGFiQtoBWbStmldljZ9CdajhFs7mZGREzuu6oPAiW1j794/vLjTSbrCz0wiRScnajZDjI8MNxgmPxhHjzBQpIpQkdgbRzymafln5ixzoyL1vhLH/F9Ct4/fzr3PHQHR6bm9wx0NlDyM/str93E3JH2N5nxiBgMv7N5wDvm5YvZzdKhorskY8THD25OOxZAh298koljFZFS1TriS7lHVP1PTnnysGagwRoAkgKSeq648wuCI6HkATnps5he5XoCaWZre++KcP2JBMCKeTjCIPBQKLelyBanEKuIDhtiyFVU9mlbGxALIGaQI8W8pLaEtLD0lGJbl/TM3t6pK11hO1ZUFFDMFEYZdieZMIghXyckZubS4LKSBV6zB3/3nMilnClFkwtznJCCI+eqq8oCqXGUqbop3Td0VAB9WU9EmU5wvNqCMaGimiMXbZLJOMZKeTjDIPBwK2LZmBDRSWh6PV6kuavQKBAzZEuZdP0aRwzeuYiE5UtlTSZm0jVp3bdUd67f9wxOFhJCAIbkdR32S6RjGekkI9Dbl02jyCdD/E5uaxZs4aU+R1rVFYVdymXFppGo6mRypbKXmpxLyeMdp9+jx75md2g1kFM15mejrC9SvSE04gGmwzbk0wYpJCPQzRqFYumRfLRkSpsNgXCku3iV3W4S7mpofZkUp7oJz9uPA5ASkhK1x1ndttnc/p0nSBkMBjIvfZG6ggimnoZtieZUEghH6csTY+iurGdg+fqQaWGyGlQ2VXIp4Tae7ue6CcvrS8lVBdKuF+nST2Wdqgo7DN+vDUoAQXBj1Z/lTVr1kgRl0wYpJCPUxZPi0IILuYoj5rew7USrA0mJiCGY0bPEvKCggI+PvQxolawdu3aiyGEFUVgNfUp5J8dr8FXo8IwST92xkokHoAU8nFKWICW2ZNC+aikQ8ijp0PjOWit61IuTe9ZkSsFBQX8d8N/MaqNBLUHdU3j6lgRqI+p+V+UXmBuUphXZTuUSFyBFPJxzJXpURw4W09VQ5u9Rw5QVdKlzNTQqZyoP4HZZu6lhrEnLy+PRqURi9pCoCkQ6JTG9cwuCE2CoOgex1U3tnOkspFLvTC/ikQyUqSQj2Mca3luP1oNURn2jd0GPNNC07DYLJyqPzXG1vWO0WikSWdfni6oPajT9rqLKwL1whcnLgB4ZX4ViWSkSCEfx6THBBHqr2HPyVr7lHZdSK9CDp4z4KnX651ZGQPbA53bJwcLaKrs0z/++fEagnx9yIoPGRM7JRJPQgr5OMY+e1NNXkEpa77/fc6Ygmg8sadLmeTgZHxUPh4Tgpibm0uLbwtaixadVQfY07h+aUZHT7svIS+9wCUp4ahVva/fKZGMZ6SQj2MKCgqwVByhwaajFQ1nzcGoa45QkJ/vLKNRa5iin0JJXUk/NY0dBoMBn1gf9FY9cDGNa5K6EjQBEJXZ45gztS2U1bZ4Zf5xicQVyDS245i8vDzCbFZgMjUEU6mE4S8O82neBgyzLy5mnBGWwY7yHSiK0nOl+jFGURQqzZVcM/MaHl/9+MUdex6G+Nmg7vmV/aK0wz8+RfrHJRMT2SMfxxiNRkJpQo2VakKoVOwZEf0bT3YplxGeQW1brUdM1XfkWOkyNd/cBucPQPycXo/5rLSGiEAdaVGBve6XSMY7UsjHMXq9HjUKYTRSTTDnbXYhT/Jv7VIuI8we0VJ8obhHHWNNqbEUoGuyrPMHwGaGhJwe5RVF4fPSCyxIDXf7rwmJxF1IIR/HOBJJRdCIkQAa8adR8WdWXNc8JVNDp6ISKopr3S/kjhwrqfpUCgoKWLt2LW//5ScAHKjz7Vm+qonqxnbpH5dMaKSPfBzjyDVy/u0vKG5RYQ2MQQnNINzS1YXir/EnOTjZI3rkJ+pPEOYbxuni02zYsAGz2UyiphKjEsB/3vsYi1+E87wKCgr4zaa9QBz7t7zONM2VMr+KZEIie+TjHIPBwI++vQqAnGU3EZw6H6pLwGbrUi4jPIPDtYd7qWFsOW48Tqo+1bniD0CiqOKMLbrLij+Opd1OtmoJoA1bY/XFqfwSyQRDCvkEIDHMjyBfH3smxKgMMLeA8VSXMhlhGVS1VFHTWuMeI7H7u08YT5ASkuJc2SeAVsJVDZyx2WepOrbn5eXRbjZTRYhzNSC5tJtkoiKFfAIghCArLoRD5xouxmF3y4SYEW4f8CypdV88eeeIFcfKPgkqe9KvMzZ7fhXHdqPRiJFAzGiI6hByx3aJZKIhhXyCkBUfTHFFA+Zw+5T87lP108PSAfdGrnSOWHEM1E5SVWJTBGeVyC4r/uj1eirRAzh75I7tEslEQwr5BCHQXIfJYuPBn/4Oo9BTd+SzLvuDtEFMCprk1sgVR8TKFP0UDAYDK1euJFlba5/IpI/ssuJPbm4uVSKUYJrxw+5Ll0u7SSYqIxJyIcTNQohDQgibEKJnkK/EIygoKKB073YA6gjknCUEU3lRj4HBjPAMDl9w34CnI2Il1DcUAEN2NinaWjTJlwKwfv1650ITGVkzuaAKZZLWHhMvl3aTTGRGGn54EFgJPO8CWySjRF5eHr6WRnywUkcg55VwpnGGV9/f3EX4MsIyyDuVR317PSG6sc8i6IhYcVJbCm31fHKyFaPJCOBcaCL6TCsmq8Jjq1ZwedpdY26rROJJjKhHrihKsaIoR1xljGR0MBqNqAA9TdQSSKUtDLWwoWk41aWcOwc8HRErqSGdhPzsPgBOmbtO9jGbzby++zTRwToWyPzjEsnY+ciFEKuFEHuFEHurq6vHqlkJFwcAQ2nGSCDnO3KupAS2dSnnzqn6joiVLj3y8r20KxqqlNAuZdvQUGYJ5IZZ8TJtrUTCIIRcCLFVCHGwl9cNQ2lIUZQXFEXJURQlJzIycvgWS4aMIwIklCYsqDmhxGJVVMxPCu5SLtQ3lPjAePKr8vuoafToNcdKRRGVqliUbl/TMiJQUHGTIX4sTZRIPJYBfeSKolw1FoZIRg+HH3zd5h3sboQW/1hMAZOIUdX2KLsoYREbjm2gxdyCv8Z/zGzsHLEC2GeeVh3GNzkXzTGNc5YnQJmIJinYh4zY4N6qkkgmHDL8cIJgMBj45ZrvoFWrmJKzGL9Js3vEkgMsm7yMdms7n579dEztKzWWdolYwXgaTE1EZS1m5cqVF+PDg6KoUYK4beGUPuuSSCYaI4paEULcBDwLRALvCiEKFUWRgbweikatIj02yD5VP206HNoA7U2gu5jH2xBlIFQXytbTW7k66eoxs620vrSrW6XykP09KhNDgsH5q+KZD46g2nacG2ZJt4pE4mCkUSsbFUVJUBRFpyhKtBRxzyczLoSDZxtQouwzOanuGnTko/LhyklXsqN8B+3W9jGxqdeIlcpDgACHnR3lNhaeZeGUCKKDe6a0lUgmKtK1MsHIig+mvtVMha5DNHtxr6xIXkGLpYWNxzaOiU29rgpUeRDCUkAb4Ny093QdZ2pbuVH2xiWSLkghn2Bkxdkn+uxvDgEfvx7JswDmxsxldtRsXtz/Im2Wth77XU3nxSScVB6C6K4LLW/IP4ufRs3yrJhRt0ki8SakkE8wpsUEoVYJDp5rsrstqg71KCOE4AHDA1S1VrH+yPpRt6lH6KGpGWpPQHSWs0y7xcq7+8+RmxlNgE6uhyKRdEbeERMMX42atKjAjtzk0+H41l7LzY2Zy2Xxl/H7fb/n8HuHETUCvV5Pbm6uy/OZ9IhYqSoBlC498m0lVTS0WbhpdoJL25ZIxgOyRz4ByYoP4eDZepSoDGiqhOYLvZb7WvDXUJlV7AjegVllduY5cfUqPKXG0p7+cegi5BvyzxIZpGOhXJtTIumBFPIJSFZcMDVNJoyBHbnJq3ufkr/zo50Yzhpo1jZzIPYACorLV+FRFIXS+lJSQlIubqw6DNpA0E8GoK7ZxLYjVdyQHYePWn5lJZLuyLtiApIZbx/wPGSNs2/oZcAT7Mm2wlvCmVY9jYrgCk6HnnZudxWVLZU0m5u79cgP2d0+KvvX850DFZitCjfKKfkSSa9IIZ+AZMQGIwTkX/AFX/3FyTfdcMymTL2QSlRjFIejD2P0Nbp0FZ4eESuKYnetdHKrbMwvZ2p0IJlxckq+RNIbUsgnIIE6H5IjAjh4rsEumH30yB3JtgSC7IpsfC2+5Cfks3DpQpfZ4ohYcfbIGyugtc4p5GUXWsgvM3KTIQEhZKZDiaQ3pJBPUC4uxpxhF3JF6VHGsdyaXq9Ha9WyqH4RZq2ZV+texWwz91Lr0HFErOh99fYNjl8HHaGH7x2sAODambEuaU8iGY/I8MMJSlZ8MJuKztEcMpWA9npoOAchPX3QBoOhS7jhW8ff4vHPHuep3U/xw0t+OGI7+o5YmQ7A+4fOkxUfTGLY2GVilEi8Ddkjn6A4ZngeF4n2Db1M1e+NG6bcwKrMVfz7yL9ZXzKyyUKOiJUeMzpDEsE3hIr6VgrKjHwpS/bGJZL+kD3yCUpmh5DvbYklG+xCnrZsUMc+NPshSo2l/HL3L0kKSWJ+7Pxh2dA5YqWgoIC8vDxWtXxIk08YjQUF7G+1TxDKzZRT8iWS/pA98glKiL+GxDA/8qsVCI6H8wcHfaxapeapRU+RFJzEw9sfpqyhbFg2OCJWrFVWNmzYQKPxApHCSJkpmA0bNrBx93FSIwOYEhU4QE0SycRGCvkEJisuhENn6yFmJpzfP6RjA7WBPHvlswgh+MYH32DP+T1Dbr+ougiVUHH88+OYzWaiRB1qYeO8LZx2s4WD51u4bIpcXFkiGQgp5BOYrPgQTl1ooT0yC2qO2pNVDYHE4ET+ctVf8FH5cHfe3fzfrv+jxdwy6OP3nN/D9LDpNNfZ240R9lQBFUo4tQRiQc38FDklXyIZCCnkExjf1moAnt9WCoqNI58MPf94VkQWb1z3Brdn3M6/Sv7Flzd9eVC98zZLG/ur9zM3Zq5zglGM6gJmRc0FJYRq7D78eclhQ7ZJIploSCGfoBQUFFD8+RYA9tvseU6O7nh9WAmx/DX+rJm3hr/l/g2Au/Pu5pe7ftlv77yougizzUxOTI5z4lGsqKVSCcWGimqhJz7Ih4hA3TDOTiKZWEghn6Dk5eXhY2nBj3aOE0eT4kuM7fyIEmKpK9QsPL6QpNokXit5jeveuI695/f2WnbP+T2ohIrZUbOdE4/i1LWct4UTHKKnTh3GFdPjhm2LRDKRkEI+QXEkvgqliTqCOGeLIFZVM+yEWAUFBWzYsIGmuiYyKzO55PQlNDU38fW8r7N299oevfPd53czPWw6gVp7RIphaiKBNJNzzV1ce8e9tFoU5ku3ikQyKKSQT1AcfulQmmjAn3IlihhRS1hI0LDqy8vLw2y+OG0/vCWcy0svZ1rzNNYVr+Mrb3+FfZX7ALtbpaCqgCWTllyswDk1P5NdJ2oBuEQOdEokg0IK+QTF4ZcOpQkFwRFbAj7CxvWXpA58cC/01pP3UXyYUjaFl3NfxqbY+Pr79t75M3ufIcw3jNszbr9YuFOOlV0nL5AU7k90sO+wbJFIJhpSyCcoDr90UrAagBKtPUlVemDTsOrrK7WtXq9nbsxcNly/gVvSb2Fd8Tryq/K5N/teAjQBFwtWHoLAaKx+4ew+Wcv8ZNkbl0gGi5yiP4ExGAzMmjWL936+Fc20XDj9IpzNh7lDrys3N5cNGzZ0ca9oNBpyc3MBe2TLD+b/gGWTl/H5uc/5StpXulbQkYO85HwDDW0W5qf07R93TOc3Go2jto6oROJNSCGf4AghMEwKJf+MEeLnwNl9w6rHIaQOgRVCdFkWzrF/bsxc5sZ0e1JYLVBdAvO+6fSP9zURyDGo6nhgONYR7dyGRDLRkK4VCbMn6zlR3UxL5CyoPgJtDcOqx2AwOH3vSkd+80Et2Fx7AixtEJXJrpMXSAj1I17v12vR7oOqgMvXEZVIvA0p5BLmTLJnGTyiTgMUqCgcdl3DEtqOHOS2qOkD+sf7Co905TqiEom3IYVcwswEPT4qwSctHbnJz+YPu65hCW3lIRBqSomnrsXcr3+8v0FViWSiIoVcgp9WzfS4YD442kCNCOd43gusXbt2WNP1hyO09cc+p5pQ1vxhHQBBref7LOtw3XSm86CqRDIRkUIuASDRz0JxVSv5phRSVGfBeGZg33YvDFVoCwoKsFUc4KxFTxUh+NHOZ3mb+my38zqiYH9ArFy5Ug50SiY0MmpFAkD72WKsTOIjm4GrxR5mq4/wkTmHvLy8IYlk9+iVgcIDt7//Fv8rGtlpm041IURjxGIx99tu93VEJZKJjhRyCQABLeeASRQrkyi1xjFHfYSPrHOGNYg4FKH1bTgJOjihxNKGlijqATl4KZEMBelakQAQqw8giBaq0LPHmkG4qoHZqqOjPoiYEmBPplXUkUo3skPI5eClRDJ4ZI9cAth92x++XsApWzgFtilcYjvEdZrPOH7Ft3uUdeXMytkJvrSc1HGERHwxEUSrHLyUSIaI7JFLALs75Np50zDjQx3B5Plej06tMOPI78B0MQWtY2alw/UxqAk//RBprcQakU6NCCOSekLl4KVEMmSkkEucfG3JHADmXXMb3/rBr1Hd+Cc49Sn8+1YwtwIunllps0HlYZT4OTQrGlbfsJg1a9ZIEZdIhogUcomTmBBfUiMDeO9gRxz3zJvhxj/DiR3w79vA3ObamZX1ZWBq5IgyCeg7v4pEIumfEQm5EOLXQogSIcR+IcRGIYTeRXZJ3MRt8yez73QdB8rtg47MuhVueA5Kt8FrXyU6pPcc4cManDz5CQCfNUYTFqAlLSpwmFZLJBObkQ52bgG+ryiKRQjxK+D7wGMjN0viLm7OSeCZD47wt89OcsdUxTmoeVnQNVxz6j3u1pXyJxZTz8WVhHobnOxvQLSgoIDP3n+Dr7e9SL0qln+d1jMvJQwhxJieq0QyXhiRkCuK8kGnP3cCX+mrrMQ7CPbVcHNOIv/ceQrbgQJ8LfaFJj5tTKRSfQ23297n27oNvGJawTklEoA5c+Z08Wv3lmp284Z/EVS1F39jCT6HdnALVWiElZfallGpKMRrW3oaI5FIBoUrww/vBta7sD6Jm1i9KIXXPi/lE1sqS9mPCntK2mPWeP5su5FV2s18S/smr5mv5ohtMiUlJV2O3/r+u8RYyklUV5GgqiJRVBKpqocv7Pt1BFNPIJvNl3JQSQag/vg+4PKxPE2JZNwwoJALIbYCMb3s+qGiKG91lPkhYAHW9VPPamA1wKRJk4ZlrGRsiNP7kcNRPieDQpIxcAKH06NSCedP7Su5S7uZuzTvkWeZzyfGbPuCFCe2w4ntPNT2GRqdFYAGxZ8ztij2madRrkRTboukDZ2zrSpC0GJG3dh3oiyJRNI/Awq5oihX9bdfCHEXcC2wVHGsJtB7PS8ALwDk5OT0WU7iGczUW6gxnuUo8QgUZnHSKeaNBPC86UZu1mzjS5qdXKXZCy8+b98ZnUWBz2yOtIZxxhZFAwHQcaRer8cXaOsU4VJNCJE0ECpnckokw2ZErhUhxHLsg5tXKIoinZzjiNzcXJr+uwHFIjhCAgqiS8/cjIbXzMsoFUlclhJA5JwbIPkKCIxEU1DA0Q0bMNt6X7/T4T9vRUsTfkyhgvT0dDecpUQyPhipj/w5QAds6Yg42Kkoyr0jtkridhyDl+b16xEoHCUeG4I5lDrFXK8PJSn3R0R2m8AzUAbE06dPs3PnTs5hX5koCiP79lUxefJkORlIIhkGI41ameIqQySeh8FgsKeTNZ5AhY0SElEQ5HCcUL2eNWvW9HtsX6JcUlKCAhwjjhCaCaUZs5khp8yVSCR25MxOSb/k5uai1WjI5hQZlFFKLHvFNK5advWw6zQajVQRgpFApnLW2cOXqWslkuEhhVzSL44VeUL1emZymjm6SkqVKF47rsJitQ2rzpAQPSUkoMPMZKqd22XqWolkeMg0tpIB6e4mefbDY/xmy1HarTZ+97VZaNSqIaW2NSZcSkV9E7M4gQ/2h4FMXSuRDB8p5JIh8+DSNHw1an6xuZh2s5VvZqp5562NzpmcdUYj6/77NkdqTPhFJlBe19rxaqG8rpWTNc1cmexHWm0z9fWMOKe5RDLREf2Efo8aOTk5yt69e8e8XYlr+ccXp/jRW4fwF2ZQrFhROV9KN69deICWhFA/EsL8mR4bzOpFKWjU0rMnkQwFIcQ+RVFyum+XPXLJsLnj0iTCA3WsXfc+amzOlwobfpgIpI3H//d+4vV+BOjkV00iGS3k3SUZEStmxLJfX9lrxIler2dqdFDPgyQSiUuRv20lIyY3NxeNRtNlmxy8lEjGDtkjl4yYgWZySiSS0UUKucQl9DeTUyKRjC7StSKRSCRejhRyiUQi8XKkkEskEomXI4VcIpFIvBwp5BKJROLluGWKvhCiGjg9xs1GADVj3OZg8VTbPNUu8FzbPNUu8FzbPNUu8DzbJiuKEtl9o1uE3B0IIfb2lqPAE/BU2zzVLvBc2zzVLvBc2zzVLvBs2zojXSsSiUTi5Ughl0gkEi9nIgn5C+42oB881TZPtQs81zZPtQs81zZPtQs82zYnE8ZHLpFIJOOVidQjl0gkknGJFHKJRCLxcsatkAshbhZCHBJC2IQQfYYPCSFOCSEOCCEKhRBjsv7cEGxbLoQ4IoQ4LoRYMwZ2hQkhtgghjnW8h/ZRbkyu2UDnL+z8oWP/fiHE7NGyZRi2LRZC1Hdco0IhxI/HyK6XhRBVQoiDfex3yzUbhF3uul6JQohtQojijnvy//VSxm3fs0GjKMq4fAEZwDRgO5DTT7lTQISn2QaogVIgBdACRcD0UbbrKWBNx+c1wK/cdc0Gc/7ACuA9QACXALvG6P83GNsWA++M5feqo91FwGzgYB/73XXNBrLLXdcrFpjd8TkIOOop37OhvMZtj1xRlGJFUY64247eGKRt84DjiqKcUBTFBPwbuGGUTbsBeLXj86vAjaPcXn8M5vxvAP6u2NkJ6IUQsR5im1tQFOVjoLafIm65ZoOwyy0oilKhKEp+x+dGoBiI71bMXd+zQTNuhXwIKMAHQoh9QojV7jamE/HAmU5/l9PzC+ZqohVFqQD7FxyI6qPcWFyzwZy/O67RUNq9VAhRJIR4TwiROQZ2DQZ3XbPB4NbrJYRIAgzArm67PPmaAV6+QpAQYisQ08uuHyqK8tYgq1moKMo5IUQUsEUIUdLRe3C3baKXbSOOFe3PriFUMyrXrBuDOf9RuUaDYDDt5mPPi9EkhFgBvAmkjbZhg8Bd12wg3Hq9hBCBwH+BhxRFaei+u5dDPOGaOfFqIVcU5SoX1HGu471KCLER+8/mEYuSC2wrBxI7/Z0AnBthnf3aJYSoFELEKopS0fHTsaqPOkblmnVjMOc/KtdoEAzYbmcxUBRlsxDiT0KICEVR3J2AyV3XrF/ceb2EEBrsIr5OUZQNvRTxyGvWmQntWhFCBAghghyfgauBXkfV3cAeIE0IkSyE0AK3AJtGuc1NwF0dn+8CevxyGMNrNpjz3wTc2RFVcAlQ73ANjTID2iaEiBFCiI7P87DfaxfGwLaBcNc16xd3Xa+ONl8CihVFeaaPYh55zbrg7tHW0XoBN2F/krYDlUBex/Y4YHPH5xTsEQdFwCHsbg+PsE25OFp+FHuExKjbBoQDHwLHOt7D3HnNejt/4F7g3o7PAvhjx/4D9BOd5AbbHui4PkXATmDBGNn1L6ACMHd8x+7xhGs2CLvcdb0uw+4m2Q8UdrxWeMI1G8pLTtGXSCQSL2dCu1YkEolkPCCFXCKRSLwcKeQSiUTi5Ughl0gkEi9HCrlEIpF4OVLIJRKJxMuRQi6RSCRezv8HVxGIZk52x2YAAAAASUVORK5CYII=\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x116758630>"
+       "<Figure size 432x288 with 1 Axes>"
       ]
      },
-     "metadata": {},
+     "metadata": {
+      "needs_background": "light"
+     },
      "output_type": "display_data"
     }
    ],
    "source": [
-    "# Generate the range of data we'd like to predict\n",
-    "test_times = np.expand_dims(np.linspace(times.min(),times.max(),200), 1)\n",
-    "predictions = model.predict(test_times)\n",
+    "# Reshape data for plotting\n",
+    "test_times = np.expand_dims(np.linspace(times.min(),times.max(), 200), 1)\n",
+    "predictions = np.asarray(model.predict(test_times))\n",
+    "predictions = np.reshape(predictions, predictions.shape[0: 2])\n",
     "\n",
-    "plt.scatter(times, accel)\n",
+    "# Call plitting functions\n",
+    "plt.scatter(times, accel, c=\"#777777\")\n",
     "for i, prediction in enumerate(predictions):\n",
-    "    plt.plot(test_times, prediction, label='{}th Quantile'.format(int(model.quantiles[i]*100)))\n",
-    "    \n",
+    "    plt.plot(test_times, prediction, label='{}th Quantile'.format(int(quantiles[i]*100)))\n",
     "plt.legend()\n",
     "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[<tf.Tensor 'q_model_5/0_q10/BiasAdd:0' shape=(?, 1) dtype=float32>,\n",
-       " <tf.Tensor 'q_model_5/1_q50/BiasAdd:0' shape=(?, 1) dtype=float32>,\n",
-       " <tf.Tensor 'q_model_5/2_q90/BiasAdd:0' shape=(?, 1) dtype=float32>]"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "model.outputs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -264,9 +236,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,5 @@
 # Tensorflow Deep Quantile Regression 
 
 An preliminary implementation of deep quantile regression in tensorflow, inspired by [sachinruk's keras implementation](https://github.com/sachinruk/KerasQuantileModel). This allows you to fit an aribtrary number of quantiles simultaneously.
+
+Compatible with Tensorflow 2.3.


### PR DESCRIPTION
Thank you for sharing this nice notebook.

As I had some issues using the original version in my TensorFlow 2.3 setup, I refactored the code to make it TensorFlow 2.3 compatible. I also added a built-in normalization step to ease its application on other more complex datasets.

If the maintainers prefer not to replace the current version compatible with TensorFlow 1.x for backward compatibility, I can submit another Pull Request with the new version of the notebook in a separate file (lets say, named 'Quantile Loss 2.3.ipynb').